### PR TITLE
feat: don't announce placeholder when have a value

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "scripts": {
     "build": "yarn clean && yarn compile",
-    "ci": "yarn clean && yarn lint && yarn test && yarn build",
+    "ci": "yarn clean && yarn lint && yarn test:coverage && yarn build",
     "clean": "rimraf lib",
     "compile": "tsc",
     "lint": "eslint . --ext .ts --cache",

--- a/src/Virtual.ts
+++ b/src/Virtual.ts
@@ -180,11 +180,6 @@ export class Virtual implements ScreenReader {
 
     this.#invalidateTreeCache();
     const tree = this.#getAccessibilityTree();
-
-    if (!tree.length) {
-      return;
-    }
-
     const currentIndex = this.#getCurrentIndexByNode(tree);
     const newActiveNode = tree.at(currentIndex);
 

--- a/src/getNodeAccessibilityData/getAccessibleAttributeLabels/getAttributesByRole.ts
+++ b/src/getNodeAccessibilityData/getAccessibleAttributeLabels/getAttributesByRole.ts
@@ -1,7 +1,15 @@
 import { ARIAPropertyMap, ARIARoleDefinitionKey, roles } from "aria-query";
 import { globalStatesAndProperties } from "../../getRole";
 
-export const getAttributesByRole = (role: string) => {
+const ignoreAttributesWithAccessibleValue = ["aria-placeholder"];
+
+export const getAttributesByRole = ({
+  accessibleValue,
+  role,
+}: {
+  accessibleValue: string;
+  role: string;
+}) => {
   const {
     props: implicitRoleAttributes = {},
     prohibitedProps: prohibitedAttributes = [],
@@ -15,7 +23,13 @@ export const getAttributesByRole = (role: string) => {
       ...Object.keys(implicitRoleAttributes),
       ...globalStatesAndProperties,
     ])
-  ).filter((attribute) => !prohibitedAttributes.includes(attribute));
+  )
+    .filter((attribute) => !prohibitedAttributes.includes(attribute))
+    .filter(
+      (attribute) =>
+        !accessibleValue ||
+        !ignoreAttributesWithAccessibleValue.includes(attribute)
+    );
 
   return uniqueAttributes.map((attribute) => [
     attribute,

--- a/src/getNodeAccessibilityData/getAccessibleAttributeLabels/index.ts
+++ b/src/getNodeAccessibilityData/getAccessibleAttributeLabels/index.ts
@@ -6,9 +6,11 @@ import { isElement } from "../../isElement";
 import { mapAttributeNameAndValueToLabel } from "./mapAttributeNameAndValueToLabel";
 
 export const getAccessibleAttributeLabels = ({
+  accessibleValue,
   node,
   role,
 }: {
+  accessibleValue: string;
   node: Node;
   role: string;
 }): string[] => {
@@ -18,7 +20,7 @@ export const getAccessibleAttributeLabels = ({
     return labels;
   }
 
-  const attributes = getAttributesByRole(role);
+  const attributes = getAttributesByRole({ accessibleValue, role });
 
   attributes.forEach(([attributeName, implicitAttributeValue]) => {
     const labelFromHtmlEquivalentAttribute =

--- a/src/getNodeAccessibilityData/getAccessibleAttributeLabels/mapAttributeNameAndValueToLabel.ts
+++ b/src/getNodeAccessibilityData/getAccessibleAttributeLabels/mapAttributeNameAndValueToLabel.ts
@@ -135,7 +135,7 @@ function token(tokenMap: Record<string, string>) {
 
 function concat(propertyName: string) {
   return function mapper({ attributeValue }) {
-    return `${propertyName} ${attributeValue}`;
+    return attributeValue ? `${propertyName} ${attributeValue}` : "";
   };
 }
 

--- a/src/getNodeAccessibilityData/getAccessibleValue.ts
+++ b/src/getNodeAccessibilityData/getAccessibleValue.ts
@@ -1,6 +1,6 @@
 import { isElement } from "../isElement";
 
-function getSelectValue(node) {
+function getSelectValue(node: HTMLSelectElement) {
   const selectedOptions = [...node.options].filter((option) => option.selected);
 
   if (node.multiple) {
@@ -14,7 +14,7 @@ function getSelectValue(node) {
   return selectedOptions[0].value;
 }
 
-function getInputValue(node) {
+function getInputValue(node: HTMLInputElement) {
   if (["checkbox", "radio"].includes(node.type)) {
     return "";
   }
@@ -29,10 +29,10 @@ export function getAccessibleValue(node: Node) {
 
   switch (node.localName) {
     case "input": {
-      return getInputValue(node);
+      return getInputValue(node as HTMLInputElement);
     }
     case "select": {
-      return getSelectValue(node);
+      return getSelectValue(node as HTMLSelectElement);
     }
   }
 

--- a/src/getNodeAccessibilityData/index.ts
+++ b/src/getNodeAccessibilityData/index.ts
@@ -26,6 +26,7 @@ export function getNodeAccessibilityData({
   });
 
   const accessibleAttributeLabels = getAccessibleAttributeLabels({
+    accessibleValue,
     node,
     role,
   });

--- a/test/int/accessibleValue.int.test.ts
+++ b/test/int/accessibleValue.int.test.ts
@@ -1,0 +1,155 @@
+import { virtual } from "../../src";
+
+describe("Placeholder Attribute Property", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("should announce a non-empty value on a text input", async () => {
+    document.body.innerHTML = `
+    <div id="label">Label</div>
+    <input type="text" aria-labelledby="label" id="search1" value="a11y"/>
+    `;
+
+    await virtual.start({ container: document.body });
+    await virtual.next();
+    await virtual.next();
+
+    expect(await virtual.lastSpokenPhrase()).toBe("textbox, Label, a11y");
+
+    await virtual.stop();
+  });
+
+  it("should not announce an empty value on a text input", async () => {
+    document.body.innerHTML = `
+    <div id="label">Label</div>
+    <input type="text" aria-labelledby="label" id="search1" value=""/>
+    `;
+
+    await virtual.start({ container: document.body });
+    await virtual.next();
+    await virtual.next();
+
+    expect(await virtual.lastSpokenPhrase()).toBe("textbox, Label");
+
+    await virtual.stop();
+  });
+
+  it("should not announce a missing value on a text input", async () => {
+    document.body.innerHTML = `
+    <div id="label">Label</div>
+    <input type="text" aria-labelledby="label" id="search1"/>
+    `;
+
+    await virtual.start({ container: document.body });
+    await virtual.next();
+    await virtual.next();
+
+    expect(await virtual.lastSpokenPhrase()).toBe("textbox, Label");
+
+    await virtual.stop();
+  });
+
+  it("should not announce a value on a checkbox input", async () => {
+    document.body.innerHTML = `
+    <div id="label">Label</div>
+    <input type="checkbox" aria-labelledby="label" id="check1" value="forbidden"/>
+    `;
+
+    await virtual.start({ container: document.body });
+    await virtual.next();
+    await virtual.next();
+
+    expect(await virtual.lastSpokenPhrase()).toBe("checkbox, Label");
+
+    await virtual.stop();
+  });
+
+  it("should not announce a value on a radio input", async () => {
+    document.body.innerHTML = `
+    <div id="label">Label</div>
+    <input type="radio" aria-labelledby="label" id="radio1" value="forbidden"/>
+    `;
+
+    await virtual.start({ container: document.body });
+    await virtual.next();
+    await virtual.next();
+
+    expect(await virtual.lastSpokenPhrase()).toBe("radio, Label");
+
+    await virtual.stop();
+  });
+
+  it("should not announce a value on a radio input", async () => {
+    document.body.innerHTML = `
+    <div id="label">Label</div>
+    <input type="radio" aria-labelledby="label" id="radio1" value="forbidden"/>
+    `;
+
+    await virtual.start({ container: document.body });
+    await virtual.next();
+    await virtual.next();
+
+    expect(await virtual.lastSpokenPhrase()).toBe("radio, Label");
+
+    await virtual.stop();
+  });
+
+  it("should announce the selected value in a select with options", async () => {
+    document.body.innerHTML = `
+    <select>
+      <option value="first">First Value</option>
+      <option value="second" selected>Second Value</option>
+      <option value="third">Third Value</option>
+    </select>
+    `;
+
+    await virtual.start({ container: document.body });
+    await virtual.next();
+
+    expect(await virtual.lastSpokenPhrase()).toBe(
+      "combobox, second, not expanded, has popup listbox"
+    );
+
+    await virtual.stop();
+  });
+
+  it("should announce the multiple selected values in a multi-select with options", async () => {
+    document.body.innerHTML = `
+    <select multiple>
+      <option value="first">First Value</option>
+      <option value="second" selected>Second Value</option>
+      <option value="third" selected>Third Value</option>
+    </select>
+    `;
+
+    await virtual.start({ container: document.body });
+    await virtual.next();
+
+    expect(await virtual.lastSpokenPhrase()).toBe(
+      "listbox, second; third, orientated vertically"
+    );
+
+    await virtual.stop();
+  });
+
+  it("should not announce empty selected values in a select with options", async () => {
+    document.body.innerHTML = `
+    <select>
+      <option value="" disabled selected>- Select some value - </option>
+      <option value="first">First Value</option>
+      <option value="second">Second Value</option>
+      <option value="third">Third Value</option>
+    </select>
+    `;
+
+    await virtual.start({ container: document.body });
+    await virtual.next();
+
+    expect(await virtual.lastSpokenPhrase()).toBe(
+      "combobox, not expanded, has popup listbox"
+    );
+
+    await virtual.stop();
+  });
+});

--- a/test/int/ariaPlaceholder.int.test.ts
+++ b/test/int/ariaPlaceholder.int.test.ts
@@ -1,0 +1,101 @@
+import { virtual } from "../../src";
+
+describe("Placeholder Attribute Property", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("should announce a non-empty aria-placeholder attribute on an input when there is no value", async () => {
+    document.body.innerHTML = `
+    <div id="label">Label</div>
+    <input type="text" aria-labelledby="label" id="search1" value="" aria-placeholder="Search..."/>
+    `;
+
+    await virtual.start({ container: document.body });
+    await virtual.next();
+    await virtual.next();
+
+    expect(await virtual.lastSpokenPhrase()).toBe(
+      "textbox, Label, placeholder Search..."
+    );
+
+    await virtual.stop();
+  });
+
+  it("should not announce an empty aria-placeholder attribute on an input when there is no value", async () => {
+    document.body.innerHTML = `
+    <div id="label">Label</div>
+    <input type="text" aria-labelledby="label" id="search1" value="" aria-placeholder=""/>
+    `;
+
+    await virtual.start({ container: document.body });
+    await virtual.next();
+    await virtual.next();
+
+    expect(await virtual.lastSpokenPhrase()).toBe("textbox, Label");
+
+    await virtual.stop();
+  });
+
+  it("should announce an input value in preference to a non-empty aria-placeholder attribute", async () => {
+    document.body.innerHTML = `
+    <div id="label">Label</div>
+    <input type="text" aria-labelledby="label" id="search1" value="a11y" aria-placeholder="Search..."/>
+    `;
+
+    await virtual.start({ container: document.body });
+    await virtual.next();
+    await virtual.next();
+
+    expect(await virtual.lastSpokenPhrase()).toBe("textbox, Label, a11y");
+
+    await virtual.stop();
+  });
+
+  it("should announce a non-empty placeholder attribute on an input when there is no value", async () => {
+    document.body.innerHTML = `
+    <div id="label">Label</div>
+    <input type="text" aria-labelledby="label" id="search1" value="" placeholder="Search..."/>
+    `;
+
+    await virtual.start({ container: document.body });
+    await virtual.next();
+    await virtual.next();
+
+    expect(await virtual.lastSpokenPhrase()).toBe(
+      "textbox, Label, placeholder Search..."
+    );
+
+    await virtual.stop();
+  });
+
+  it("should not announce an empty placeholder attribute on an input when there is no value", async () => {
+    document.body.innerHTML = `
+    <div id="label">Label</div>
+    <input type="text" aria-labelledby="label" id="search1" value="" placeholder=""/>
+    `;
+
+    await virtual.start({ container: document.body });
+    await virtual.next();
+    await virtual.next();
+
+    expect(await virtual.lastSpokenPhrase()).toBe("textbox, Label");
+
+    await virtual.stop();
+  });
+
+  it("should announce an input value in preference to a non-empty placeholder attribute", async () => {
+    document.body.innerHTML = `
+    <div id="label">Label</div>
+    <input type="text" aria-labelledby="label" id="search1" value="a11y" placeholder="Search..."/>
+    `;
+
+    await virtual.start({ container: document.body });
+    await virtual.next();
+    await virtual.next();
+
+    expect(await virtual.lastSpokenPhrase()).toBe("textbox, Label, a11y");
+
+    await virtual.stop();
+  });
+});


### PR DESCRIPTION
Fixes #7 

Only announce `placeholder` or `aria-placeholder` if don't have an accessible value already (as superfluous).

Also adds test coverage for accessible value calculation.