### PR TITLE
feat: handle aria value priorities

### DIFF
--- a/src/Virtual.ts
+++ b/src/Virtual.ts
@@ -67,17 +67,34 @@ const observedAttributes = [
  * - aria-live
  * - aria-relevant
  *
+ * When live regions are marked as polite, assistive technologies SHOULD
+ * announce updates at the next graceful opportunity, such as at the end of
+ * speaking the current sentence or when the user pauses typing. When live
+ * regions are marked as assertive, assistive technologies SHOULD notify the
+ * user immediately.
+ *
  * REF:
  *
  * - https://w3c.github.io/aria/#live_region_roles
  * - https://w3c.github.io/aria/#window_roles
  * - https://w3c.github.io/aria/#attrs_liveregions
+ * - https://w3c.github.io/aria/#aria-live
  */
 
 /**
  * TODO: handle logical descendants via aria-activedescendant and aria-owns
  *
  * REF: https://w3c.github.io/aria/#state_prop_def
+ */
+
+/**
+ * TODO: When a modal element is displayed, assistive technologies SHOULD
+ * navigate to the element unless focus has explicitly been set elsewhere. Some
+ * assistive technologies limit navigation to the modal element's contents. If
+ * focus moves to an element outside the modal element, assistive technologies
+ * SHOULD NOT limit navigation to the modal element.
+ *
+ * REF: https://w3c.github.io/aria/#aria-modal
  */
 
 const observeDOM = (function () {
@@ -116,6 +133,16 @@ const observeDOM = (function () {
 async function tick() {
   return await new Promise<void>((resolve) => setTimeout(() => resolve()));
 }
+
+/**
+ * TODO: When an assistive technology reading cursor moves from one article to
+ * another, assistive technologies SHOULD set user agent focus on the article
+ * that contains the reading cursor. If the reading cursor lands on a focusable
+ * element inside the article, the assistive technology MAY set focus on that
+ * element in lieu of setting focus on the containing article.
+ *
+ * REF: https://w3c.github.io/aria/#feed
+ */
 
 export class Virtual implements ScreenReader {
   #activeNode: AccessibilityNode | null = null;
@@ -457,8 +484,89 @@ export class Virtual implements ScreenReader {
     this.#checkContainer();
     await tick();
 
-    // TODO: decide what this means as there is no established "common" command
-    // set for different screen readers.
+    /**
+     * TODO: Assistive technologies SHOULD enable users to quickly navigate to
+     * elements with role banner.
+     *
+     * REF: https://w3c.github.io/aria/#banner
+     */
+
+    /**
+     * TODO: Assistive technologies SHOULD enable users to quickly navigate to
+     * elements with role complementary.
+     *
+     * REF: https://w3c.github.io/aria/#complementary
+     */
+
+    /**
+     * TODO: Assistive technologies SHOULD enable users to quickly navigate to
+     * elements with role contentinfo.
+     *
+     * REF: https://w3c.github.io/aria/#contentinfo
+     */
+
+    /**
+     * TODO: Assistive technologies SHOULD enable users to quickly navigate to
+     * figures.
+     *
+     * REF: https://w3c.github.io/aria/#figure
+     */
+
+    /**
+     * TODO: Assistive technologies SHOULD enable users to quickly navigate to
+     * elements with role form.
+     *
+     * REF: https://w3c.github.io/aria/#form
+     */
+
+    /**
+     * TODO: Assistive technologies SHOULD enable users to quickly navigate to
+     * landmark regions.
+     *
+     * REF: https://w3c.github.io/aria/#landmark
+     */
+
+    /**
+     * TODO: Assistive technologies SHOULD enable users to quickly navigate to
+     * elements with role main.
+     *
+     * REF: https://w3c.github.io/aria/#main
+     */
+
+    /**
+     * TODO: Assistive technologies SHOULD enable users to quickly navigate to
+     * elements with role navigation.
+     *
+     * REF: https://w3c.github.io/aria/#navigation
+     */
+
+    /**
+     * TODO: Assistive technologies SHOULD enable users to quickly navigate to
+     * elements with role region.
+     *
+     * REF: https://w3c.github.io/aria/#region
+     */
+
+    /**
+     * TODO: Assistive technologies SHOULD enable users to quickly navigate to
+     * elements with role search.
+     *
+     * REF: https://w3c.github.io/aria/#search
+     */
+
+    /**
+     * TODO:  However, when aria-flowto is provided with multiple ID
+     * references, assistive technologies SHOULD present the referenced
+     * elements as path choices.
+     *
+     * In the case of one or more ID references, user agents or assistive
+     * technologies SHOULD give the user the option of navigating to any of the
+     * targeted elements. The name of the path can be determined by the name of
+     * the target element of the aria-flowto attribute. Accessibility APIs can
+     * provide named path relationships.
+     *
+     * REF: https://w3c.github.io/aria/#aria-flowto
+     */
 
     notImplemented();
   }

--- a/src/createAccessibilityTree.ts
+++ b/src/createAccessibilityTree.ts
@@ -36,7 +36,8 @@ function shouldIgnoreChildren(tree: AccessibilityNodeTree) {
     // TODO: improve comparison on whether the children are superfluous
     // to include.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    accessibleName === (node.textContent || (node as any).value)?.trim()
+    accessibleName ===
+    (node.textContent || `${(node as any).value}` || "")?.trim()
   );
 }
 

--- a/src/getNodeAccessibilityData/getAccessibleAttributeLabels/getAttributesByRole.ts
+++ b/src/getNodeAccessibilityData/getAccessibleAttributeLabels/getAttributesByRole.ts
@@ -1,5 +1,5 @@
 import { ARIAPropertyMap, ARIARoleDefinitionKey, roles } from "aria-query";
-import { globalStatesAndProperties } from "../../getRole";
+import { globalStatesAndProperties } from "../getRole";
 
 const ignoreAttributesWithAccessibleValue = ["aria-placeholder"];
 

--- a/src/getNodeAccessibilityData/getAccessibleAttributeLabels/getLabelFromAriaAttribute.ts
+++ b/src/getNodeAccessibilityData/getAccessibleAttributeLabels/getLabelFromAriaAttribute.ts
@@ -9,8 +9,11 @@ export const getLabelFromAriaAttribute = ({
 }) => {
   const attributeValue = node.getAttribute(attributeName);
 
-  return mapAttributeNameAndValueToLabel({
-    attributeName,
-    attributeValue,
-  });
+  return {
+    label: mapAttributeNameAndValueToLabel({
+      attributeName,
+      attributeValue,
+    }),
+    value: attributeValue,
+  };
 };

--- a/src/getNodeAccessibilityData/getAccessibleAttributeLabels/getLabelFromHtmlEquivalentAttribute.ts
+++ b/src/getNodeAccessibilityData/getAccessibleAttributeLabels/getLabelFromHtmlEquivalentAttribute.ts
@@ -1,7 +1,10 @@
 import { mapAttributeNameAndValueToLabel } from "./mapAttributeNameAndValueToLabel";
 
 // REF: https://www.w3.org/TR/html-aria/#docconformance-attr
-const ariaToHTMLAttributeMapping = {
+const ariaToHTMLAttributeMapping: Record<
+  string,
+  Array<{ name: string; negative?: boolean }>
+> = {
   "aria-checked": [{ name: "checked" }],
   "aria-disabled": [{ name: "disabled" }],
   // "aria-hidden": [{ name: "hidden" }],
@@ -27,7 +30,7 @@ export const getLabelFromHtmlEquivalentAttribute = ({
   const htmlAttribute = ariaToHTMLAttributeMapping[attributeName];
 
   if (!htmlAttribute?.length) {
-    return null;
+    return { label: "", value: "" };
   }
 
   for (const { name, negative = false } of htmlAttribute) {
@@ -39,9 +42,9 @@ export const getLabelFromHtmlEquivalentAttribute = ({
     });
 
     if (label) {
-      return label;
+      return { label, value: attributeValue };
     }
   }
 
-  return null;
+  return { label: "", value: "" };
 };

--- a/src/getNodeAccessibilityData/getAccessibleAttributeLabels/getLabelFromImplicitHtmlElementValue.ts
+++ b/src/getNodeAccessibilityData/getAccessibleAttributeLabels/getLabelFromImplicitHtmlElementValue.ts
@@ -21,8 +21,11 @@ export const getLabelFromImplicitHtmlElementValue = ({
   const { localName } = node;
   const implicitValue = mapLocalNameToImplicitValue[attributeName]?.[localName];
 
-  return mapAttributeNameAndValueToLabel({
-    attributeName,
-    attributeValue: implicitValue,
-  });
+  return {
+    label: mapAttributeNameAndValueToLabel({
+      attributeName,
+      attributeValue: implicitValue,
+    }),
+    value: implicitValue,
+  };
 };

--- a/src/getNodeAccessibilityData/getAccessibleAttributeLabels/index.ts
+++ b/src/getNodeAccessibilityData/getAccessibleAttributeLabels/index.ts
@@ -4,6 +4,7 @@ import { getLabelFromHtmlEquivalentAttribute } from "./getLabelFromHtmlEquivalen
 import { getLabelFromImplicitHtmlElementValue } from "./getLabelFromImplicitHtmlElementValue";
 import { isElement } from "../../isElement";
 import { mapAttributeNameAndValueToLabel } from "./mapAttributeNameAndValueToLabel";
+import { postProcessLabels } from "./postProcessLabels";
 
 export const getAccessibleAttributeLabels = ({
   accessibleValue,
@@ -14,46 +15,59 @@ export const getAccessibleAttributeLabels = ({
   node: Node;
   role: string;
 }): string[] => {
-  const labels = [];
-
   if (!isElement(node)) {
-    return labels;
+    return [];
   }
 
+  const labels: Record<string, { label: string; value: string }> = {};
   const attributes = getAttributesByRole({ accessibleValue, role });
 
   attributes.forEach(([attributeName, implicitAttributeValue]) => {
-    const labelFromHtmlEquivalentAttribute =
-      getLabelFromHtmlEquivalentAttribute({
-        attributeName,
-        node,
-      });
-
-    if (labelFromHtmlEquivalentAttribute) {
-      labels.push(labelFromHtmlEquivalentAttribute);
-
-      return;
-    }
-
-    const labelFromAriaAttribute = getLabelFromAriaAttribute({
+    const {
+      label: labelFromHtmlEquivalentAttribute,
+      value: valueFromHtmlEquivalentAttribute,
+    } = getLabelFromHtmlEquivalentAttribute({
       attributeName,
       node,
     });
 
-    if (labelFromAriaAttribute) {
-      labels.push(labelFromAriaAttribute);
+    if (labelFromHtmlEquivalentAttribute) {
+      labels[attributeName] = {
+        label: labelFromHtmlEquivalentAttribute,
+        value: valueFromHtmlEquivalentAttribute,
+      };
 
       return;
     }
 
-    const labelFromImplicitHtmlElementValue =
-      getLabelFromImplicitHtmlElementValue({
+    const { label: labelFromAriaAttribute, value: valueFromAriaAttribute } =
+      getLabelFromAriaAttribute({
         attributeName,
         node,
       });
 
+    if (labelFromAriaAttribute) {
+      labels[attributeName] = {
+        label: labelFromAriaAttribute,
+        value: valueFromAriaAttribute,
+      };
+
+      return;
+    }
+
+    const {
+      label: labelFromImplicitHtmlElementValue,
+      value: valueFromImplicitHtmlElementValue,
+    } = getLabelFromImplicitHtmlElementValue({
+      attributeName,
+      node,
+    });
+
     if (labelFromImplicitHtmlElementValue) {
-      labels.push(labelFromImplicitHtmlElementValue);
+      labels[attributeName] = {
+        label: labelFromImplicitHtmlElementValue,
+        value: valueFromImplicitHtmlElementValue,
+      };
 
       return;
     }
@@ -66,11 +80,14 @@ export const getAccessibleAttributeLabels = ({
     );
 
     if (labelFromImplicitAriaAttributeValue) {
-      labels.push(labelFromImplicitAriaAttributeValue);
+      labels[attributeName] = {
+        label: labelFromImplicitAriaAttributeValue,
+        value: implicitAttributeValue,
+      };
 
       return;
     }
   });
 
-  return labels;
+  return postProcessLabels({ labels, role });
 };

--- a/src/getNodeAccessibilityData/getAccessibleAttributeLabels/mapAttributeNameAndValueToLabel.ts
+++ b/src/getNodeAccessibilityData/getAccessibleAttributeLabels/mapAttributeNameAndValueToLabel.ts
@@ -16,7 +16,10 @@ enum State {
 }
 
 // https://w3c.github.io/aria/#state_prop_def
-const ariaPropertyToVirtualLabelMap = {
+const ariaPropertyToVirtualLabelMap: Record<
+  string,
+  ((...args: unknown[]) => string) | null
+> = {
   "aria-activedescendant": null, // TODO: decide what to announce here + implement focus logic
   "aria-atomic": null, // Handled by live region logic
   "aria-autocomplete": token({
@@ -53,7 +56,13 @@ const ariaPropertyToVirtualLabelMap = {
   "aria-flowto": null, // TODO: decide what to announce here + implement focus logic
   "aria-grabbed": null, // Deprecated in WAI-ARIA 1.1
   "aria-haspopup": token({
-    false: null, // https://w3c.github.io/aria/#aria-haspopup
+    /**
+     * Assistive technologies SHOULD NOT expose the aria-haspopup property if
+     * it has a value of false.
+     *
+     * REF: // https://w3c.github.io/aria/#aria-haspopup
+     */
+    false: null,
     true: "has popup menu",
     menu: "has popup menu",
     listbox: "has popup listbox",
@@ -101,10 +110,8 @@ const ariaPropertyToVirtualLabelMap = {
   }),
   "aria-valuemax": number("max value"),
   "aria-valuemin": number("min value"),
-  // TODO: don't announce if have an aria-valuetext
-  // TODO: map to percentage as per https://w3c.github.io/aria/#aria-valuenow for certain roles
   "aria-valuenow": number("current value"),
-  "aria-valuetext": string("current value"), // TODO: don't announce if have a value?
+  "aria-valuetext": string("current value"),
 };
 
 function state(stateValue: State) {

--- a/src/getNodeAccessibilityData/getAccessibleAttributeLabels/postProcessAriaValueNow.ts
+++ b/src/getNodeAccessibilityData/getAccessibleAttributeLabels/postProcessAriaValueNow.ts
@@ -1,0 +1,56 @@
+const percentageBasedValueRoles = ["progressbar", "scrollbar"];
+
+const isNumberLike = (value: string) => {
+  return !isNaN(parseFloat(value));
+};
+
+const toNumber = (value: string) => parseFloat(value);
+const toPercentageLabel = (value: number | string) => `current value ${value}%`;
+
+/**
+ * If aria-valuetext is specified, assistive technologies render that instead
+ * of the value of aria-valuenow.
+ *
+ * REF: https://w3c.github.io/aria/#aria-valuenow
+ */
+export const postProcessAriaValueNow = ({
+  max,
+  min,
+  role,
+  value,
+}: {
+  max: string;
+  min: string;
+  role: string;
+  value: string;
+}) => {
+  if (!percentageBasedValueRoles.includes(role)) {
+    return value;
+  }
+
+  if (!isNumberLike(value)) {
+    return value;
+  }
+
+  /**
+   * For progressbar elements and scrollbar elements, assistive technologies
+   * SHOULD render the value to users as a percent, calculated as a position
+   * on the range from aria-valuemin to aria-valuemax if both are defined,
+   * otherwise the actual value with a percent indicator. For elements with
+   * role slider and spinbutton, assistive technologies SHOULD render the
+   * actual value to users.
+   *
+   * REF: https://w3c.github.io/aria/#aria-valuenow
+   */
+
+  if (isNumberLike(max) && isNumberLike(min)) {
+    const percentage = +(
+      ((toNumber(value) - toNumber(min)) / (toNumber(max) - toNumber(min))) *
+      100
+    ).toFixed(2);
+
+    return toPercentageLabel(percentage);
+  }
+
+  return toPercentageLabel(value);
+};

--- a/src/getNodeAccessibilityData/getAccessibleAttributeLabels/postProcessLabels.ts
+++ b/src/getNodeAccessibilityData/getAccessibleAttributeLabels/postProcessLabels.ts
@@ -1,0 +1,38 @@
+import { postProcessAriaValueNow } from "./postProcessAriaValueNow";
+
+const priorityReplacementMap: [string, string][] = [
+  ["aria-colindextext", "aria-colindex"],
+  ["aria-rowindextext", "aria-rowindex"],
+  /**
+   * If aria-valuetext is specified, assistive technologies SHOULD render that
+   * value instead of the value of aria-valuenow.
+   *
+   * REF: https://w3c.github.io/aria/#aria-valuetext
+   */
+  ["aria-valuetext", "aria-valuenow"],
+];
+
+export const postProcessLabels = ({
+  labels,
+  role,
+}: {
+  labels: Record<string, { label: string; value: string }>;
+  role: string;
+}) => {
+  for (const [preferred, dropped] of priorityReplacementMap) {
+    if (labels[preferred] && labels[dropped]) {
+      labels[dropped].value = "";
+    }
+  }
+
+  if (labels["aria-valuenow"]) {
+    labels["aria-valuenow"].label = postProcessAriaValueNow({
+      value: labels["aria-valuenow"].value,
+      min: labels["aria-valuemin"]?.value,
+      max: labels["aria-valuemax"]?.value,
+      role,
+    });
+  }
+
+  return Object.values(labels).map(({ label }) => label);
+};

--- a/src/getNodeAccessibilityData/getAccessibleValue.ts
+++ b/src/getNodeAccessibilityData/getAccessibleValue.ts
@@ -1,25 +1,66 @@
 import { isElement } from "../isElement";
 
+type HTMLElementWithValue =
+  | HTMLButtonElement
+  | HTMLDataElement
+  | HTMLInputElement
+  | HTMLLIElement
+  | HTMLMeterElement
+  | HTMLOptionElement
+  | HTMLProgressElement
+  | HTMLParamElement;
+
+const ignoredInputTypes = ["checkbox", "radio"];
+const allowedLocalNames = [
+  "button",
+  "data",
+  "input",
+  // "li",
+  "meter",
+  "option",
+  "progress",
+  "param",
+];
+
 function getSelectValue(node: HTMLSelectElement) {
-  const selectedOptions = [...node.options].filter((option) => option.selected);
+  const selectedOptions = [...node.options].filter(
+    (optionElement) => optionElement.selected
+  );
 
   if (node.multiple) {
-    return [...selectedOptions].map((opt) => opt.value).join("; ");
+    return [...selectedOptions]
+      .map((optionElement) => getValue(optionElement))
+      .join("; ");
   }
 
   if (selectedOptions.length === 0) {
     return "";
   }
 
-  return selectedOptions[0].value;
+  return getValue(selectedOptions[0]);
 }
 
 function getInputValue(node: HTMLInputElement) {
-  if (["checkbox", "radio"].includes(node.type)) {
+  if (ignoredInputTypes.includes(node.type)) {
     return "";
   }
 
-  return node.value;
+  return getValue(node);
+}
+
+function getValue(node: HTMLElementWithValue) {
+  if (!allowedLocalNames.includes(node.localName)) {
+    return "";
+  }
+
+  if (
+    node.getAttribute("aria-valuetext") ||
+    node.getAttribute("aria-valuenow")
+  ) {
+    return "";
+  }
+
+  return typeof node.value === "number" ? `${node.value}` : node.value;
 }
 
 export function getAccessibleValue(node: Node) {
@@ -36,5 +77,5 @@ export function getAccessibleValue(node: Node) {
     }
   }
 
-  return "";
+  return getValue(node as HTMLElementWithValue);
 }

--- a/src/getNodeAccessibilityData/getRole.ts
+++ b/src/getNodeAccessibilityData/getRole.ts
@@ -1,6 +1,6 @@
 import { getRole as getImplicitRole } from "dom-accessibility-api";
 import { getRoles } from "@testing-library/dom";
-import { isElement } from "./isElement";
+import { isElement } from "../isElement";
 import { roles } from "aria-query";
 
 export const presentationRoles = ["presentation", "none"];

--- a/src/getNodeAccessibilityData/index.ts
+++ b/src/getNodeAccessibilityData/index.ts
@@ -2,11 +2,39 @@ import {
   childrenPresentationalRoles,
   getRole,
   presentationRoles,
-} from "../getRole";
+} from "./getRole";
 import { getAccessibleAttributeLabels } from "./getAccessibleAttributeLabels";
 import { getAccessibleDescription } from "./getAccessibleDescription";
 import { getAccessibleName } from "./getAccessibleName";
 import { getAccessibleValue } from "./getAccessibleValue";
+import { isElement } from "../isElement";
+
+const getSpokenRole = ({ isGeneric, isPresentational, node, role }) => {
+  if (isPresentational || isGeneric) {
+    return "";
+  }
+
+  if (isElement(node)) {
+    /**
+     * Assistive technologies SHOULD use the value of aria-roledescription when
+     * presenting the role of an element, but SHOULD NOT change other
+     * functionality based on the role of an element that has a value for
+     * aria-roledescription. For example, an assistive technology that provides
+     * functions for navigating to the next region or button SHOULD allow those
+     * functions to navigate to regions and buttons that have an
+     * aria-roledescription.
+     *
+     * REF: https://w3c.github.io/aria/#aria-roledescription
+     */
+    const roledescription = node.getAttribute("aria-roledescription");
+
+    if (roledescription) {
+      return roledescription;
+    }
+  }
+
+  return role;
+};
 
 export function getNodeAccessibilityData({
   inheritedImplicitPresentational,
@@ -38,7 +66,7 @@ export function getNodeAccessibilityData({
     inheritedImplicitPresentational ||
     childrenPresentationalRoles.includes(role);
 
-  const spokenRole = isPresentational || isGeneric ? "" : role;
+  const spokenRole = getSpokenRole({ isGeneric, isPresentational, node, role });
   const amendedAccessibleDescription =
     accessibleDescription === accessibleName ? "" : accessibleDescription;
 

--- a/test/int/accessibleValue.int.test.ts
+++ b/test/int/accessibleValue.int.test.ts
@@ -152,4 +152,55 @@ describe("Placeholder Attribute Property", () => {
 
     await virtual.stop();
   });
+
+  it("should announce the value for a progress element", async () => {
+    document.body.innerHTML = `
+    <label for="element1">Loading:</label>
+    <progress id="element1" max="100" value="23"></progress>
+    `;
+
+    await virtual.start({ container: document.body });
+    await virtual.next();
+    await virtual.next();
+
+    expect(await virtual.lastSpokenPhrase()).toBe(
+      "progressbar, Loading:, 23, max value 100"
+    );
+
+    await virtual.stop();
+  });
+
+  it("should not announce the value for a progress element which has an aria-valuenow", async () => {
+    document.body.innerHTML = `
+    <label for="element1">Loading:</label>
+    <progress id="element1" max="100" value="23" aria-valuenow="24"></progress>
+    `;
+
+    await virtual.start({ container: document.body });
+    await virtual.next();
+    await virtual.next();
+
+    expect(await virtual.lastSpokenPhrase()).toBe(
+      "progressbar, Loading:, max value 100, current value 24%"
+    );
+
+    await virtual.stop();
+  });
+
+  it("should not announce the value for a progress element which has an aria-valuetext", async () => {
+    document.body.innerHTML = `
+    <label for="element1">Loading:</label>
+    <progress id="element1" max="100" value="23" aria-valuetext="massive"></progress>
+    `;
+
+    await virtual.start({ container: document.body });
+    await virtual.next();
+    await virtual.next();
+
+    expect(await virtual.lastSpokenPhrase()).toBe(
+      "progressbar, Loading:, current value massive, max value 100"
+    );
+
+    await virtual.stop();
+  });
 });

--- a/test/int/ariaRoleDescription.int.test.ts
+++ b/test/int/ariaRoleDescription.int.test.ts
@@ -1,0 +1,39 @@
+import { virtual } from "../../src";
+
+describe("Aria Role Description", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("should announce the aria-roledescription in place of the role", async () => {
+    document.body.innerHTML = `
+    <div role="article" aria-roledescription="slide" id="slide" aria-labelledby="slideheading">
+      <h1 id="slideheading">Quarterly Report</h1>
+      <!-- remaining slide contents -->
+    </div>
+    `;
+
+    await virtual.start({ container: document.body });
+    await virtual.next();
+
+    expect(await virtual.lastSpokenPhrase()).toBe("slide, Quarterly Report");
+
+    await virtual.stop();
+  });
+
+  it("should announce the aria-roledescription in place of the role", async () => {
+    document.body.innerHTML = `
+    <article aria-roledescription="slide" id="slide" aria-labelledby="slideheading">
+      <h1 id="slideheading">Quarterly Report</h1>
+      <!-- remaining slide contents -->
+    </article>
+    `;
+
+    await virtual.start({ container: document.body });
+    await virtual.next();
+
+    expect(await virtual.lastSpokenPhrase()).toBe("slide, Quarterly Report");
+
+    await virtual.stop();
+  });
+});

--- a/test/int/ariaValueNow.int.test.ts
+++ b/test/int/ariaValueNow.int.test.ts
@@ -1,0 +1,407 @@
+import { virtual } from "../../src";
+
+describe("Label Priority Replacement", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  describe("progressbar", () => {
+    it("should announce aria-valuenow on progressbar roles as a percentage when no range is provided", async () => {
+      document.body.innerHTML = `
+      <span id="element1">Label</span>
+      <span role="progressbar" aria-labelledby="element1" aria-valuenow="1">
+        <svg width="300" height="10">
+          <rect height="10" width="100" stroke="black" fill="red" />
+          <rect height="10" width="200" fill="white" />
+        </svg>
+      </span>
+    `;
+
+      await virtual.start({ container: document.body });
+      await virtual.next();
+      await virtual.next();
+
+      expect(await virtual.lastSpokenPhrase()).toBe(
+        "progressbar, Label, current value 1%"
+      );
+
+      await virtual.stop();
+    });
+
+    it("should announce aria-valuenow on progressbar roles as a percentage when only aria-valuemin is provided", async () => {
+      document.body.innerHTML = `
+      <span id="element1">Label</span>
+      <span role="progressbar" aria-labelledby="element1" aria-valuenow="1" aria-valuemin="1">
+        <svg width="300" height="10">
+          <rect height="10" width="100" stroke="black" fill="red" />
+          <rect height="10" width="200" fill="white" />
+        </svg>
+      </span>
+    `;
+
+      await virtual.start({ container: document.body });
+      await virtual.next();
+      await virtual.next();
+
+      expect(await virtual.lastSpokenPhrase()).toBe(
+        "progressbar, Label, min value 1, current value 1%"
+      );
+
+      await virtual.stop();
+    });
+
+    it("should announce aria-valuenow on progressbar roles as a percentage when only aria-valuemax is provided", async () => {
+      document.body.innerHTML = `
+      <span id="element1">Label</span>
+      <span role="progressbar" aria-labelledby="element1" aria-valuenow="1" aria-valuemax="3">
+        <svg width="300" height="10">
+          <rect height="10" width="100" stroke="black" fill="red" />
+          <rect height="10" width="200" fill="white" />
+        </svg>
+      </span>
+    `;
+
+      await virtual.start({ container: document.body });
+      await virtual.next();
+      await virtual.next();
+
+      expect(await virtual.lastSpokenPhrase()).toBe(
+        "progressbar, Label, max value 3, current value 1%"
+      );
+
+      await virtual.stop();
+    });
+
+    it("should announce aria-valuenow on progressbar roles as a percentage when only min is provided", async () => {
+      document.body.innerHTML = `
+      <span id="element1">Label</span>
+      <span role="progressbar" aria-labelledby="element1" aria-valuenow="1" min="1">
+        <svg width="300" height="10">
+          <rect height="10" width="100" stroke="black" fill="red" />
+          <rect height="10" width="200" fill="white" />
+        </svg>
+      </span>
+    `;
+
+      await virtual.start({ container: document.body });
+      await virtual.next();
+      await virtual.next();
+
+      expect(await virtual.lastSpokenPhrase()).toBe(
+        "progressbar, Label, min value 1, current value 1%"
+      );
+
+      await virtual.stop();
+    });
+
+    it("should announce aria-valuenow on progressbar roles as a percentage when only max is provided", async () => {
+      document.body.innerHTML = `
+      <span id="element1">Label</span>
+      <span role="progressbar" aria-labelledby="element1" aria-valuenow="1" max="3">
+        <svg width="300" height="10">
+          <rect height="10" width="100" stroke="black" fill="red" />
+          <rect height="10" width="200" fill="white" />
+        </svg>
+      </span>
+    `;
+
+      await virtual.start({ container: document.body });
+      await virtual.next();
+      await virtual.next();
+
+      expect(await virtual.lastSpokenPhrase()).toBe(
+        "progressbar, Label, max value 3, current value 1%"
+      );
+
+      await virtual.stop();
+    });
+
+    it("should announce aria-valuenow on progressbar roles as a zero percentage of a positive aria-valuemin - aria-valuemax range", async () => {
+      document.body.innerHTML = `
+      <span id="element1">Label</span>
+      <span role="progressbar" aria-labelledby="element1" aria-valuenow="1" aria-valuemin="1" aria-valuemax="3">
+        <svg width="300" height="10">
+          <rect height="10" width="100" stroke="black" fill="red" />
+          <rect height="10" width="200" fill="white" />
+        </svg>
+      </span>
+    `;
+
+      await virtual.start({ container: document.body });
+      await virtual.next();
+      await virtual.next();
+
+      expect(await virtual.lastSpokenPhrase()).toBe(
+        "progressbar, Label, max value 3, min value 1, current value 0%"
+      );
+
+      await virtual.stop();
+    });
+
+    it("should announce aria-valuenow on progressbar roles as a non-zero percentage of a positive aria-valuemin - aria-valuemax range", async () => {
+      document.body.innerHTML = `
+      <span id="element1">Label</span>
+      <span role="progressbar" aria-labelledby="element1" aria-valuenow="2" aria-valuemin="1" aria-valuemax="3">
+        <svg width="300" height="10">
+          <rect height="10" width="100" stroke="black" fill="red" />
+          <rect height="10" width="200" fill="white" />
+        </svg>
+      </span>
+    `;
+
+      await virtual.start({ container: document.body });
+      await virtual.next();
+      await virtual.next();
+
+      expect(await virtual.lastSpokenPhrase()).toBe(
+        "progressbar, Label, max value 3, min value 1, current value 50%"
+      );
+
+      await virtual.stop();
+    });
+
+    it("should announce aria-valuenow on progressbar roles as a non-zero percentage rounded to at most 2 decimal places", async () => {
+      document.body.innerHTML = `
+      <span id="element1">Label</span>
+      <span role="progressbar" aria-labelledby="element1" aria-valuenow="2" aria-valuemin="0" aria-valuemax="3">
+        <svg width="300" height="10">
+          <rect height="10" width="100" stroke="black" fill="red" />
+          <rect height="10" width="200" fill="white" />
+        </svg>
+      </span>
+    `;
+
+      await virtual.start({ container: document.body });
+      await virtual.next();
+      await virtual.next();
+
+      expect(await virtual.lastSpokenPhrase()).toBe(
+        "progressbar, Label, max value 3, min value 0, current value 66.67%"
+      );
+
+      await virtual.stop();
+    });
+
+    it("should announce aria-valuenow on progressbar roles as a percentage of a range spanning across 0", async () => {
+      document.body.innerHTML = `
+      <span id="element1">Label</span>
+      <span role="progressbar" aria-labelledby="element1" aria-valuenow="2" aria-valuemin="-2" aria-valuemax="3">
+        <svg width="300" height="10">
+          <rect height="10" width="100" stroke="black" fill="red" />
+          <rect height="10" width="200" fill="white" />
+        </svg>
+      </span>
+    `;
+
+      await virtual.start({ container: document.body });
+      await virtual.next();
+      await virtual.next();
+
+      expect(await virtual.lastSpokenPhrase()).toBe(
+        "progressbar, Label, max value 3, min value -2, current value 80%"
+      );
+
+      await virtual.stop();
+    });
+  });
+
+  describe("scrollbar", () => {
+    it("should announce aria-valuenow on scrollbar roles as a percentage when no range is provided", async () => {
+      document.body.innerHTML = `
+      <span id="element1">Label</span>
+      <span role="scrollbar" aria-labelledby="element1" aria-valuenow="1">
+        <svg width="300" height="10">
+          <rect height="10" width="100" stroke="black" fill="red" />
+          <rect height="10" width="200" fill="white" />
+        </svg>
+      </span>
+    `;
+
+      await virtual.start({ container: document.body });
+      await virtual.next();
+      await virtual.next();
+
+      expect(await virtual.lastSpokenPhrase()).toBe(
+        "scrollbar, Label, orientated vertically, max value 100, min value 0, current value 1%"
+      );
+
+      await virtual.stop();
+    });
+
+    it("should announce aria-valuenow on scrollbar roles as a percentage when only aria-valuemin is provided", async () => {
+      document.body.innerHTML = `
+      <span id="element1">Label</span>
+      <span role="scrollbar" aria-labelledby="element1" aria-valuenow="1" aria-valuemin="1">
+        <svg width="300" height="10">
+          <rect height="10" width="100" stroke="black" fill="red" />
+          <rect height="10" width="200" fill="white" />
+        </svg>
+      </span>
+    `;
+
+      await virtual.start({ container: document.body });
+      await virtual.next();
+      await virtual.next();
+
+      expect(await virtual.lastSpokenPhrase()).toBe(
+        "scrollbar, Label, orientated vertically, max value 100, min value 1, current value 0%"
+      );
+
+      await virtual.stop();
+    });
+
+    it("should announce aria-valuenow on scrollbar roles as a percentage when only aria-valuemax is provided", async () => {
+      document.body.innerHTML = `
+      <span id="element1">Label</span>
+      <span role="scrollbar" aria-labelledby="element1" aria-valuenow="1" aria-valuemax="3">
+        <svg width="300" height="10">
+          <rect height="10" width="100" stroke="black" fill="red" />
+          <rect height="10" width="200" fill="white" />
+        </svg>
+      </span>
+    `;
+
+      await virtual.start({ container: document.body });
+      await virtual.next();
+      await virtual.next();
+
+      expect(await virtual.lastSpokenPhrase()).toBe(
+        "scrollbar, Label, orientated vertically, max value 3, min value 0, current value 33.33%"
+      );
+
+      await virtual.stop();
+    });
+
+    it("should announce aria-valuenow on scrollbar roles as a percentage when only min is provided", async () => {
+      document.body.innerHTML = `
+      <span id="element1">Label</span>
+      <span role="scrollbar" aria-labelledby="element1" aria-valuenow="1" min="1">
+        <svg width="300" height="10">
+          <rect height="10" width="100" stroke="black" fill="red" />
+          <rect height="10" width="200" fill="white" />
+        </svg>
+      </span>
+    `;
+
+      await virtual.start({ container: document.body });
+      await virtual.next();
+      await virtual.next();
+
+      expect(await virtual.lastSpokenPhrase()).toBe(
+        "scrollbar, Label, orientated vertically, max value 100, min value 1, current value 0%"
+      );
+
+      await virtual.stop();
+    });
+
+    it("should announce aria-valuenow on scrollbar roles as a percentage when only max is provided", async () => {
+      document.body.innerHTML = `
+      <span id="element1">Label</span>
+      <span role="scrollbar" aria-labelledby="element1" aria-valuenow="1" max="3">
+        <svg width="300" height="10">
+          <rect height="10" width="100" stroke="black" fill="red" />
+          <rect height="10" width="200" fill="white" />
+        </svg>
+      </span>
+    `;
+
+      await virtual.start({ container: document.body });
+      await virtual.next();
+      await virtual.next();
+
+      expect(await virtual.lastSpokenPhrase()).toBe(
+        "scrollbar, Label, orientated vertically, max value 3, min value 0, current value 33.33%"
+      );
+
+      await virtual.stop();
+    });
+
+    it("should announce aria-valuenow on scrollbar roles as a zero percentage of a positive aria-valuemin - aria-valuemax range", async () => {
+      document.body.innerHTML = `
+      <span id="element1">Label</span>
+      <span role="scrollbar" aria-labelledby="element1" aria-valuenow="1" aria-valuemin="1" aria-valuemax="3">
+        <svg width="300" height="10">
+          <rect height="10" width="100" stroke="black" fill="red" />
+          <rect height="10" width="200" fill="white" />
+        </svg>
+      </span>
+    `;
+
+      await virtual.start({ container: document.body });
+      await virtual.next();
+      await virtual.next();
+
+      expect(await virtual.lastSpokenPhrase()).toBe(
+        "scrollbar, Label, orientated vertically, max value 3, min value 1, current value 0%"
+      );
+
+      await virtual.stop();
+    });
+
+    it("should announce aria-valuenow on scrollbar roles as a non-zero percentage of a positive aria-valuemin - aria-valuemax range", async () => {
+      document.body.innerHTML = `
+      <span id="element1">Label</span>
+      <span role="scrollbar" aria-labelledby="element1" aria-valuenow="2" aria-valuemin="1" aria-valuemax="3">
+        <svg width="300" height="10">
+          <rect height="10" width="100" stroke="black" fill="red" />
+          <rect height="10" width="200" fill="white" />
+        </svg>
+      </span>
+    `;
+
+      await virtual.start({ container: document.body });
+      await virtual.next();
+      await virtual.next();
+
+      expect(await virtual.lastSpokenPhrase()).toBe(
+        "scrollbar, Label, orientated vertically, max value 3, min value 1, current value 50%"
+      );
+
+      await virtual.stop();
+    });
+
+    it("should announce aria-valuenow on scrollbar roles as a non-zero percentage rounded to at most 2 decimal places", async () => {
+      document.body.innerHTML = `
+      <span id="element1">Label</span>
+      <span role="scrollbar" aria-labelledby="element1" aria-valuenow="2" aria-valuemin="0" aria-valuemax="3">
+        <svg width="300" height="10">
+          <rect height="10" width="100" stroke="black" fill="red" />
+          <rect height="10" width="200" fill="white" />
+        </svg>
+      </span>
+    `;
+
+      await virtual.start({ container: document.body });
+      await virtual.next();
+      await virtual.next();
+
+      expect(await virtual.lastSpokenPhrase()).toBe(
+        "scrollbar, Label, orientated vertically, max value 3, min value 0, current value 66.67%"
+      );
+
+      await virtual.stop();
+    });
+
+    it("should announce aria-valuenow on scrollbar roles as a percentage of a range spanning across 0", async () => {
+      document.body.innerHTML = `
+      <span id="element1">Label</span>
+      <span role="scrollbar" aria-labelledby="element1" aria-valuenow="2" aria-valuemin="-2" aria-valuemax="3">
+        <svg width="300" height="10">
+          <rect height="10" width="100" stroke="black" fill="red" />
+          <rect height="10" width="200" fill="white" />
+        </svg>
+      </span>
+    `;
+
+      await virtual.start({ container: document.body });
+      await virtual.next();
+      await virtual.next();
+
+      expect(await virtual.lastSpokenPhrase()).toBe(
+        "scrollbar, Label, orientated vertically, max value 3, min value -2, current value 80%"
+      );
+
+      await virtual.stop();
+    });
+  });
+});

--- a/test/int/labelPriorityReplacement.int.test.ts
+++ b/test/int/labelPriorityReplacement.int.test.ts
@@ -1,0 +1,29 @@
+import { virtual } from "../../src";
+
+describe("Label Priority Replacement", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("should announce aria-valuetext in preference to aria-valuenow", async () => {
+    document.body.innerHTML = `
+    <span id="element1">Pandemic Size:</span>
+    <span role="progressbar" aria-labelledby="element1" aria-valuemin="1" aria-valuemax="3" aria-valuenow="1" aria-valuetext="small">
+      <svg width="300" height="10">
+        <rect height="10" width="100" stroke="black" fill="red" />
+        <rect height="10" width="200" fill="white" />
+      </svg>
+    </span>
+    `;
+
+    await virtual.start({ container: document.body });
+    await virtual.next();
+    await virtual.next();
+
+    expect(await virtual.lastSpokenPhrase()).toBe(
+      "progressbar, Pandemic Size:, current value small, max value 3, min value 1"
+    );
+
+    await virtual.stop();
+  });
+});

--- a/test/wpt/html-aam/roles.int.test.ts
+++ b/test/wpt/html-aam/roles.int.test.ts
@@ -365,9 +365,9 @@ describe("HTML-AAM Role Verification Tests", () => {
       "end of status",
       "x", // TODO: FAIL p should have paragraph role
       "x", // WONTFIX generic ignored by screen readers
-      "progressbar",
+      "progressbar, 0",
       "x",
-      "end of progressbar",
+      "end of progressbar, 0",
       "x",
       "x", // TODO: FAIL s should have deletion role
       "x", // WONTFIX generic ignored by screen readers

--- a/test/wpt/wai-aria/role/roles.int.test.ts
+++ b/test/wpt/wai-aria/role/roles.int.test.ts
@@ -61,7 +61,7 @@ function defaultAriaAttributes(role) {
       return ", orientated horizontally, max value 100, min value 0";
     }
     case "spinbutton": {
-      return ", current value 0";
+      return ", 0";
     }
     case "toolbar": {
       return ", orientated horizontally";


### PR DESCRIPTION
Fixes #5 

Also:

- Handles the percentage logic for aria-valuenow on some roles.
- Adds support for `aria-roledescription` announcement in place of `role`

