### PR TITLE
fix: cater to environments where there is no `window`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,16 @@ module.exports = {
     "plugin:require-extensions/recommended",
     "prettier",
   ],
-  plugins: ["@typescript-eslint", "require-extensions"],
-  rules: { "sort-imports": ["error", { ignoreCase: true }] },
+  plugins: ["require-extensions", "@typescript-eslint"],
+  rules: {
+    "sort-imports": ["error", { ignoreCase: true }],
+    quotes: ["error", "double"],
+  },
+  env: {
+    browser: true,
+    node: true,
+  },
+  globals: {
+    jest: "readonly",
+  },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,7 +10,7 @@ module.exports = {
   plugins: ["require-extensions", "@typescript-eslint"],
   rules: {
     "sort-imports": ["error", { ignoreCase: true }],
-    quotes: ["error", "double"],
+    quotes: ["error", "double", { avoidEscape: true }],
   },
   env: {
     browser: true,

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,7 +14,7 @@ module.exports = {
       statements: 98,
     },
   },
-  setupFilesAfterEnv: ["./test/jest.setup.ts"],
+  setupFilesAfterEnv: ["<rootDir>/test/jest.setup.ts"],
   transform: {
     "^.+\\.tsx?$": ["ts-jest", { tsconfig: "./tsconfig.test.json" }],
   },

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "eslint-plugin-require-extensions": "^0.1.3",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "jsdom": "^24.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rimraf": "^5.0.5",

--- a/src/commands/getElementNode.ts
+++ b/src/commands/getElementNode.ts
@@ -1,5 +1,5 @@
-import { AccessibilityNode } from '../createAccessibilityTree.js';
-import { getElementFromNode } from '../getElementFromNode.js';
+import { AccessibilityNode } from "../createAccessibilityTree.js";
+import { getElementFromNode } from "../getElementFromNode.js";
 
 export function getElementNode(accessibilityNode: AccessibilityNode): Element {
   const { node } = accessibilityNode;

--- a/src/commands/getIndexByRoleAndAttributes.ts
+++ b/src/commands/getIndexByRoleAndAttributes.ts
@@ -1,9 +1,9 @@
 import {
   AccessibilityNode,
   END_OF_ROLE_PREFIX,
-} from '../createAccessibilityTree.js';
-import { matchesAccessibleAttributes, matchesRoles } from './nodeMatchers.js';
-import type { AriaAttributes } from './types.js';
+} from "../createAccessibilityTree.js";
+import { matchesAccessibleAttributes, matchesRoles } from "./nodeMatchers.js";
+import type { AriaAttributes } from "./types.js";
 
 export interface GetIndexFilters {
   /** Matches a node only if the node has any of these roles */

--- a/src/commands/getNextIndexByIdRefsAttribute.ts
+++ b/src/commands/getNextIndexByIdRefsAttribute.ts
@@ -1,8 +1,8 @@
-import { getElementNode } from './getElementNode.js';
-import { getIdRefsByAttribute } from '../getIdRefsByAttribute.js';
-import { getNodeByIdRef } from '../getNodeByIdRef.js';
-import { isElement } from '../isElement.js';
-import { VirtualCommandArgs } from './types.js';
+import { getElementNode } from "./getElementNode.js";
+import { getIdRefsByAttribute } from "../getIdRefsByAttribute.js";
+import { getNodeByIdRef } from "../getNodeByIdRef.js";
+import { isElement } from "../isElement.js";
+import { VirtualCommandArgs } from "./types.js";
 
 export interface GetNextIndexByIdRefsAttributeArgs extends VirtualCommandArgs {
   attributeName: string;

--- a/src/commands/getNextIndexByRoleAndAttributes.ts
+++ b/src/commands/getNextIndexByRoleAndAttributes.ts
@@ -1,8 +1,8 @@
 import {
   getIndexByRoleAndAttributes,
   type GetIndexFilters,
-} from './getIndexByRoleAndAttributes.js';
-import type { VirtualCommandArgs } from './types.js';
+} from "./getIndexByRoleAndAttributes.js";
+import type { VirtualCommandArgs } from "./types.js";
 
 export type GetNextIndexArgs = Omit<VirtualCommandArgs, "container">;
 

--- a/src/commands/getPreviousIndexByRoleAndAttributes.ts
+++ b/src/commands/getPreviousIndexByRoleAndAttributes.ts
@@ -1,8 +1,8 @@
 import {
   getIndexByRoleAndAttributes,
   type GetIndexFilters,
-} from './getIndexByRoleAndAttributes.js';
-import type { GetNextIndexArgs } from './getNextIndexByRoleAndAttributes.js';
+} from "./getIndexByRoleAndAttributes.js";
+import type { GetNextIndexArgs } from "./getNextIndexByRoleAndAttributes.js";
 
 type GetPreviousIndexArgs = GetNextIndexArgs;
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,11 +1,11 @@
-import { getNextIndexByRoleAndAttributes } from './getNextIndexByRoleAndAttributes.js';
-import { getPreviousIndexByRoleAndAttributes } from './getPreviousIndexByRoleAndAttributes.js';
-import { jumpToControlledElement } from './jumpToControlledElement.js';
-import { jumpToDetailsElement } from './jumpToDetailsElement.js';
-import { jumpToErrorMessageElement } from './jumpToErrorMessageElement.js';
-import { moveToNextAlternateReadingOrderElement } from './moveToNextAlternateReadingOrderElement.js';
-import { moveToPreviousAlternateReadingOrderElement } from './moveToPreviousAlternateReadingOrderElement.js';
-import { VirtualCommandArgs } from './types.js';
+import { getNextIndexByRoleAndAttributes } from "./getNextIndexByRoleAndAttributes.js";
+import { getPreviousIndexByRoleAndAttributes } from "./getPreviousIndexByRoleAndAttributes.js";
+import { jumpToControlledElement } from "./jumpToControlledElement.js";
+import { jumpToDetailsElement } from "./jumpToDetailsElement.js";
+import { jumpToErrorMessageElement } from "./jumpToErrorMessageElement.js";
+import { moveToNextAlternateReadingOrderElement } from "./moveToNextAlternateReadingOrderElement.js";
+import { moveToPreviousAlternateReadingOrderElement } from "./moveToPreviousAlternateReadingOrderElement.js";
+import { VirtualCommandArgs } from "./types.js";
 
 const quickLandmarkNavigationRoles = [
   /**

--- a/src/commands/jumpToControlledElement.ts
+++ b/src/commands/jumpToControlledElement.ts
@@ -1,5 +1,5 @@
-import { getNextIndexByIdRefsAttribute } from './getNextIndexByIdRefsAttribute.js';
-import { VirtualCommandArgs } from './types.js';
+import { getNextIndexByIdRefsAttribute } from "./getNextIndexByIdRefsAttribute.js";
+import { VirtualCommandArgs } from "./types.js";
 
 export interface JumpToControlledElementCommandArgs extends VirtualCommandArgs {
   index?: number;

--- a/src/commands/jumpToDetailsElement.ts
+++ b/src/commands/jumpToDetailsElement.ts
@@ -1,5 +1,5 @@
-import { getNextIndexByIdRefsAttribute } from './getNextIndexByIdRefsAttribute.js';
-import { VirtualCommandArgs } from './types.js';
+import { getNextIndexByIdRefsAttribute } from "./getNextIndexByIdRefsAttribute.js";
+import { VirtualCommandArgs } from "./types.js";
 
 /**
  * aria-details:

--- a/src/commands/jumpToErrorMessageElement.ts
+++ b/src/commands/jumpToErrorMessageElement.ts
@@ -1,5 +1,5 @@
-import { getNextIndexByIdRefsAttribute } from './getNextIndexByIdRefsAttribute.js';
-import { VirtualCommandArgs } from './types.js';
+import { getNextIndexByIdRefsAttribute } from "./getNextIndexByIdRefsAttribute.js";
+import { VirtualCommandArgs } from "./types.js";
 
 export interface JumpToErrorMessageElementCommandArgs
   extends VirtualCommandArgs {

--- a/src/commands/moveToNextAlternateReadingOrderElement.ts
+++ b/src/commands/moveToNextAlternateReadingOrderElement.ts
@@ -1,5 +1,5 @@
-import { getNextIndexByIdRefsAttribute } from './getNextIndexByIdRefsAttribute.js';
-import { VirtualCommandArgs } from './types.js';
+import { getNextIndexByIdRefsAttribute } from "./getNextIndexByIdRefsAttribute.js";
+import { VirtualCommandArgs } from "./types.js";
 
 export interface MoveToNextAlternateReadingOrderElement
   extends VirtualCommandArgs {

--- a/src/commands/moveToPreviousAlternateReadingOrderElement.ts
+++ b/src/commands/moveToPreviousAlternateReadingOrderElement.ts
@@ -1,5 +1,5 @@
-import { isElement } from '../isElement.js';
-import { VirtualCommandArgs } from './types.js';
+import { isElement } from "../isElement.js";
+import { VirtualCommandArgs } from "./types.js";
 
 export interface MoveToNextAlternateReadingOrderElement
   extends VirtualCommandArgs {

--- a/src/commands/nodeMatchers.ts
+++ b/src/commands/nodeMatchers.ts
@@ -1,5 +1,5 @@
-import { AccessibilityNode } from '../createAccessibilityTree.js';
-import { AriaAttributes } from './types.js';
+import { AccessibilityNode } from "../createAccessibilityTree.js";
+import { AriaAttributes } from "./types.js";
 
 export function matchesRoles(
   node: AccessibilityNode,

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -1,4 +1,4 @@
-import { AccessibilityNode } from '../createAccessibilityTree.js';
+import { AccessibilityNode } from "../createAccessibilityTree.js";
 
 export type AriaAttributes = Record<string, string>;
 

--- a/src/createAccessibilityTree.ts
+++ b/src/createAccessibilityTree.ts
@@ -1,10 +1,10 @@
-import { AccessibleAttributeToLabelMap } from './getNodeAccessibilityData/getAccessibleAttributeLabels/index.js';
-import { getIdRefsByAttribute } from './getIdRefsByAttribute.js';
-import { getNodeAccessibilityData } from './getNodeAccessibilityData/index.js';
-import { getNodeByIdRef } from './getNodeByIdRef.js';
-import { HTMLElementWithValue } from './getNodeAccessibilityData/getAccessibleValue.js';
-import { isDialogRole } from './isDialogRole.js';
-import { isElement } from './isElement.js';
+import { AccessibleAttributeToLabelMap } from "./getNodeAccessibilityData/getAccessibleAttributeLabels/index.js";
+import { getIdRefsByAttribute } from "./getIdRefsByAttribute.js";
+import { getNodeAccessibilityData } from "./getNodeAccessibilityData/index.js";
+import { getNodeByIdRef } from "./getNodeByIdRef.js";
+import { HTMLElementWithValue } from "./getNodeAccessibilityData/getAccessibleValue.js";
+import { isDialogRole } from "./isDialogRole.js";
+import { isElement } from "./isElement.js";
 import { isInaccessible } from "dom-accessibility-api";
 
 export const END_OF_ROLE_PREFIX = "end of";
@@ -123,6 +123,8 @@ function getOwnedNodes(node: Node, container: Node) {
   return ownedNodes;
 }
 
+const TEXT_NODE = 3;
+
 function isHiddenFromAccessibilityTree(node: Node | null): node is null {
   if (!node) {
     return true;
@@ -130,7 +132,7 @@ function isHiddenFromAccessibilityTree(node: Node | null): node is null {
 
   // `node.textContent` is only `null` for `document` and `doctype`.
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  if (node.nodeType === Node.TEXT_NODE && !!node.textContent!.trim()) {
+  if (node.nodeType === TEXT_NODE && !!node.textContent!.trim()) {
     return false;
   }
 

--- a/src/getElementFromNode.ts
+++ b/src/getElementFromNode.ts
@@ -1,4 +1,4 @@
-import { isElement } from './isElement.js';
+import { isElement } from "./isElement.js";
 
 export const getElementFromNode = (node: Node): HTMLElement => {
   return isElement(node) ? node : node.parentElement;

--- a/src/getItemText.ts
+++ b/src/getItemText.ts
@@ -1,4 +1,4 @@
-import { AccessibilityNode } from './createAccessibilityTree.js';
+import { AccessibilityNode } from "./createAccessibilityTree.js";
 
 export const getItemText = (
   accessibilityNode: Pick<

--- a/src/getLiveSpokenPhrase.ts
+++ b/src/getLiveSpokenPhrase.ts
@@ -1,9 +1,9 @@
-import { getAccessibleName } from './getNodeAccessibilityData/getAccessibleName.js';
-import { getAccessibleValue } from './getNodeAccessibilityData/getAccessibleValue.js';
-import { getElementFromNode } from './getElementFromNode.js';
-import { getRole } from './getNodeAccessibilityData/getRole.js';
-import { isElement } from './isElement.js';
-import { sanitizeString } from './sanitizeString.js';
+import { getAccessibleName } from "./getNodeAccessibilityData/getAccessibleName.js";
+import { getAccessibleValue } from "./getNodeAccessibilityData/getAccessibleValue.js";
+import { getElementFromNode } from "./getElementFromNode.js";
+import { getRole } from "./getNodeAccessibilityData/getRole.js";
+import { isElement } from "./isElement.js";
+import { sanitizeString } from "./sanitizeString.js";
 
 /**
  * Live region roles:
@@ -101,6 +101,8 @@ function getRemovalsSpokenPhrase({ removedNodes }: { removedNodes: NodeList }) {
   );
 }
 
+const TEXT_NODE = 3;
+
 /**
  * TODO: When text changes are denoted as relevant, user agents MUST monitor
  * any descendant node change that affects the text alternative computation of
@@ -127,7 +129,7 @@ function getTextSpokenPhrase({
       }
 
       return Array.from(addedNodes)
-        .filter((node) => node.nodeType === Node.TEXT_NODE)
+        .filter((node) => node.nodeType === TEXT_NODE)
         .map(getSpokenPhraseForNode);
     }
     case "characterData": {

--- a/src/getNodeAccessibilityData/getAccessibleAttributeLabels/getAttributesByRole.ts
+++ b/src/getNodeAccessibilityData/getAccessibleAttributeLabels/getAttributesByRole.ts
@@ -1,5 +1,5 @@
 import { ARIARoleDefinitionKey, roles } from "aria-query";
-import { globalStatesAndProperties } from '../getRole.js';
+import { globalStatesAndProperties } from "../getRole.js";
 
 const ignoreAttributesWithAccessibleValue = ["aria-placeholder"];
 

--- a/src/getNodeAccessibilityData/getAccessibleAttributeLabels/getLabelFromAriaAttribute.ts
+++ b/src/getNodeAccessibilityData/getAccessibleAttributeLabels/getLabelFromAriaAttribute.ts
@@ -1,4 +1,4 @@
-import { mapAttributeNameAndValueToLabel } from './mapAttributeNameAndValueToLabel.js';
+import { mapAttributeNameAndValueToLabel } from "./mapAttributeNameAndValueToLabel.js";
 
 export const getLabelFromAriaAttribute = ({
   attributeName,

--- a/src/getNodeAccessibilityData/getAccessibleAttributeLabels/getLabelFromHtmlEquivalentAttribute.ts
+++ b/src/getNodeAccessibilityData/getAccessibleAttributeLabels/getLabelFromHtmlEquivalentAttribute.ts
@@ -1,4 +1,4 @@
-import { mapAttributeNameAndValueToLabel } from './mapAttributeNameAndValueToLabel.js';
+import { mapAttributeNameAndValueToLabel } from "./mapAttributeNameAndValueToLabel.js";
 
 const isNotMatchingElement = ({
   elements,

--- a/src/getNodeAccessibilityData/getAccessibleAttributeLabels/getLabelFromImplicitHtmlElementValue.ts
+++ b/src/getNodeAccessibilityData/getAccessibleAttributeLabels/getLabelFromImplicitHtmlElementValue.ts
@@ -1,4 +1,4 @@
-import { mapAttributeNameAndValueToLabel } from './mapAttributeNameAndValueToLabel.js';
+import { mapAttributeNameAndValueToLabel } from "./mapAttributeNameAndValueToLabel.js";
 
 const mapLocalNameToImplicitValue: Record<string, Record<string, string>> = {
   "aria-level": {

--- a/src/getNodeAccessibilityData/getAccessibleAttributeLabels/index.ts
+++ b/src/getNodeAccessibilityData/getAccessibleAttributeLabels/index.ts
@@ -1,10 +1,10 @@
-import { getAttributesByRole } from './getAttributesByRole.js';
-import { getLabelFromAriaAttribute } from './getLabelFromAriaAttribute.js';
-import { getLabelFromHtmlEquivalentAttribute } from './getLabelFromHtmlEquivalentAttribute.js';
-import { getLabelFromImplicitHtmlElementValue } from './getLabelFromImplicitHtmlElementValue.js';
-import { isElement } from '../../isElement.js';
-import { mapAttributeNameAndValueToLabel } from './mapAttributeNameAndValueToLabel.js';
-import { postProcessLabels } from './postProcessLabels.js';
+import { getAttributesByRole } from "./getAttributesByRole.js";
+import { getLabelFromAriaAttribute } from "./getLabelFromAriaAttribute.js";
+import { getLabelFromHtmlEquivalentAttribute } from "./getLabelFromHtmlEquivalentAttribute.js";
+import { getLabelFromImplicitHtmlElementValue } from "./getLabelFromImplicitHtmlElementValue.js";
+import { isElement } from "../../isElement.js";
+import { mapAttributeNameAndValueToLabel } from "./mapAttributeNameAndValueToLabel.js";
+import { postProcessLabels } from "./postProcessLabels.js";
 
 export type AccessibleAttributeToLabelMap = Record<
   string,

--- a/src/getNodeAccessibilityData/getAccessibleAttributeLabels/mapAttributeNameAndValueToLabel.ts
+++ b/src/getNodeAccessibilityData/getAccessibleAttributeLabels/mapAttributeNameAndValueToLabel.ts
@@ -1,7 +1,7 @@
-import { getAccessibleName } from '../getAccessibleName.js';
-import { getAccessibleValue } from '../getAccessibleValue.js';
-import { getItemText } from '../../getItemText.js';
-import { getNodeByIdRef } from '../../getNodeByIdRef.js';
+import { getAccessibleName } from "../getAccessibleName.js";
+import { getAccessibleValue } from "../getAccessibleValue.js";
+import { getItemText } from "../../getItemText.js";
+import { getNodeByIdRef } from "../../getNodeByIdRef.js";
 
 enum State {
   BUSY = "busy",

--- a/src/getNodeAccessibilityData/getAccessibleAttributeLabels/postProcessLabels.ts
+++ b/src/getNodeAccessibilityData/getAccessibleAttributeLabels/postProcessLabels.ts
@@ -1,5 +1,5 @@
-import type { AccessibleAttributeToLabelMap } from './/index.js';
-import { postProcessAriaValueNow } from './postProcessAriaValueNow.js';
+import type { AccessibleAttributeToLabelMap } from ".//index.js";
+import { postProcessAriaValueNow } from "./postProcessAriaValueNow.js";
 
 const priorityReplacementMap: [string, string][] = [
   ["aria-colindextext", "aria-colindex"],

--- a/src/getNodeAccessibilityData/getAccessibleDescription.ts
+++ b/src/getNodeAccessibilityData/getAccessibleDescription.ts
@@ -1,5 +1,5 @@
 import { computeAccessibleDescription } from "dom-accessibility-api";
-import { isElement } from '../isElement.js';
+import { isElement } from "../isElement.js";
 
 export function getAccessibleDescription(node: Node) {
   return isElement(node) ? computeAccessibleDescription(node).trim() : "";

--- a/src/getNodeAccessibilityData/getAccessibleName.ts
+++ b/src/getNodeAccessibilityData/getAccessibleName.ts
@@ -1,6 +1,6 @@
 import { computeAccessibleName } from "dom-accessibility-api";
-import { isElement } from '../isElement.js';
-import { sanitizeString } from '../sanitizeString.js';
+import { isElement } from "../isElement.js";
+import { sanitizeString } from "../sanitizeString.js";
 
 export function getAccessibleName(node: Node) {
   return isElement(node)

--- a/src/getNodeAccessibilityData/getAccessibleValue.ts
+++ b/src/getNodeAccessibilityData/getAccessibleValue.ts
@@ -1,4 +1,4 @@
-import { isElement } from '../isElement.js';
+import { isElement } from "../isElement.js";
 
 export type HTMLElementWithValue =
   | HTMLButtonElement

--- a/src/getNodeAccessibilityData/getRole.ts
+++ b/src/getNodeAccessibilityData/getRole.ts
@@ -39,8 +39,8 @@ const FOCUSABLE_SELECTOR = [
   "button:not([disabled])",
   "select:not([disabled])",
   "textarea:not([disabled])",
-  "[contenteditable=\"\"]",
-  "[contenteditable=\"true\"]",
+  '[contenteditable=""]',
+  '[contenteditable="true"]',
   "a[href]",
   "[tabindex]:not([disabled])",
 ].join(", ");

--- a/src/getNodeAccessibilityData/getRole.ts
+++ b/src/getNodeAccessibilityData/getRole.ts
@@ -1,6 +1,6 @@
 import { getRole as getImplicitRole } from "dom-accessibility-api";
 import { getRoles } from "@testing-library/dom";
-import { isElement } from '../isElement.js';
+import { isElement } from "../isElement.js";
 import { roles } from "aria-query";
 
 export const presentationRoles = ["presentation", "none"];
@@ -39,8 +39,8 @@ const FOCUSABLE_SELECTOR = [
   "button:not([disabled])",
   "select:not([disabled])",
   "textarea:not([disabled])",
-  '[contenteditable=""]',
-  '[contenteditable="true"]',
+  "[contenteditable=\"\"]",
+  "[contenteditable=\"true\"]",
   "a[href]",
   "[tabindex]:not([disabled])",
 ].join(", ");

--- a/src/getNodeAccessibilityData/index.ts
+++ b/src/getNodeAccessibilityData/index.ts
@@ -1,10 +1,10 @@
 import { ARIARoleDefinitionKey, roles } from "aria-query";
-import { getRole, presentationRoles } from './getRole.js';
-import { getAccessibleAttributeLabels } from './getAccessibleAttributeLabels/index.js';
-import { getAccessibleDescription } from './getAccessibleDescription.js';
-import { getAccessibleName } from './getAccessibleName.js';
-import { getAccessibleValue } from './getAccessibleValue.js';
-import { isElement } from '../isElement.js';
+import { getRole, presentationRoles } from "./getRole.js";
+import { getAccessibleAttributeLabels } from "./getAccessibleAttributeLabels/index.js";
+import { getAccessibleDescription } from "./getAccessibleDescription.js";
+import { getAccessibleName } from "./getAccessibleName.js";
+import { getAccessibleValue } from "./getAccessibleValue.js";
+import { isElement } from "../isElement.js";
 
 const childrenPresentationalRoles = roles
   .entries()

--- a/src/getNodeByIdRef.ts
+++ b/src/getNodeByIdRef.ts
@@ -1,4 +1,4 @@
-import { isElement } from './isElement.js';
+import { isElement } from "./isElement.js";
 
 export function getNodeByIdRef({
   container,

--- a/src/getSpokenPhrase.ts
+++ b/src/getSpokenPhrase.ts
@@ -1,4 +1,4 @@
-import { AccessibilityNode } from './createAccessibilityTree.js';
+import { AccessibilityNode } from "./createAccessibilityTree.js";
 
 export const getSpokenPhrase = (accessibilityNode: AccessibilityNode) => {
   const {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { StartOptions, Virtual } from './Virtual.js';
+import { StartOptions, Virtual } from "./Virtual.js";
 
 /**
  * [API Reference](https://www.guidepup.dev/docs/api/class-virtual)

--- a/src/isElement.ts
+++ b/src/isElement.ts
@@ -1,3 +1,5 @@
+const ELEMENT_NODE = 1;
+
 export function isElement(node: Node): node is HTMLElement {
-  return node.nodeType === Node.ELEMENT_NODE;
+  return node.nodeType === ELEMENT_NODE;
 }

--- a/src/observeDOM.ts
+++ b/src/observeDOM.ts
@@ -1,7 +1,8 @@
-import { isElement } from './isElement.js';
+import { isElement } from "./isElement.js";
 
 export const observeDOM = (function () {
-  const MutationObserver = window.MutationObserver;
+  const MutationObserver =
+    typeof window !== "undefined" ? window.MutationObserver : null;
 
   return function observeDOM(
     node: Node,

--- a/test/int/accessibleValue.int.test.ts
+++ b/test/int/accessibleValue.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 
 describe("Placeholder Attribute Property", () => {
   afterEach(async () => {

--- a/test/int/act.int.test.ts
+++ b/test/int/act.int.test.ts
@@ -1,5 +1,5 @@
 import { getByText, queryByText } from "@testing-library/dom";
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 
 function setupButtonPage() {
   document.body.innerHTML = `

--- a/test/int/actionsMenuButton.js
+++ b/test/int/actionsMenuButton.js
@@ -14,7 +14,7 @@ function setupActionsMenuButton() {
       this.domNode = domNode;
       this.performMenuAction = performMenuAction;
       this.buttonNode = domNode.querySelector("button");
-      this.menuNode = domNode.querySelector("[role=\"menu\"]");
+      this.menuNode = domNode.querySelector('[role="menu"]');
       this.currentMenuitem = {};
       this.menuitemNodes = [];
       this.firstMenuitem = false;
@@ -30,7 +30,7 @@ function setupActionsMenuButton() {
 
       this.menuNode.addEventListener("keydown", this.onMenuKeydown.bind(this));
 
-      var nodes = domNode.querySelectorAll("[role=\"menuitem\"]");
+      var nodes = domNode.querySelectorAll('[role="menuitem"]');
 
       for (var i = 0; i < nodes.length; i++) {
         var menuitem = nodes[i];

--- a/test/int/actionsMenuButton.js
+++ b/test/int/actionsMenuButton.js
@@ -14,7 +14,7 @@ function setupActionsMenuButton() {
       this.domNode = domNode;
       this.performMenuAction = performMenuAction;
       this.buttonNode = domNode.querySelector("button");
-      this.menuNode = domNode.querySelector('[role="menu"]');
+      this.menuNode = domNode.querySelector("[role=\"menu\"]");
       this.currentMenuitem = {};
       this.menuitemNodes = [];
       this.firstMenuitem = false;
@@ -30,7 +30,7 @@ function setupActionsMenuButton() {
 
       this.menuNode.addEventListener("keydown", this.onMenuKeydown.bind(this));
 
-      var nodes = domNode.querySelectorAll('[role="menuitem"]');
+      var nodes = domNode.querySelectorAll("[role=\"menuitem\"]");
 
       for (var i = 0; i < nodes.length; i++) {
         var menuitem = nodes[i];

--- a/test/int/activeNode.int.test.ts
+++ b/test/int/activeNode.int.test.ts
@@ -1,5 +1,5 @@
-import { setupBasicPage } from '../utils.js';
-import { virtual } from '../../src/index.js';
+import { setupBasicPage } from "../utils.js";
+import { virtual } from "../../src/index.js";
 
 describe("Active Node", () => {
   beforeEach(() => {

--- a/test/int/alertdialog.int.test.ts
+++ b/test/int/alertdialog.int.test.ts
@@ -1,5 +1,5 @@
 import { screen } from "@testing-library/dom";
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 
 function setupDialogPage() {
   document.body.innerHTML = `

--- a/test/int/allowedAccessibilityChildRoles.int.test.ts
+++ b/test/int/allowedAccessibilityChildRoles.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 
 describe("Allowed Accessibility Child Roles", () => {
   afterEach(async () => {

--- a/test/int/ariaActiveDescendant.int.test.ts
+++ b/test/int/ariaActiveDescendant.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 
 describe("Aria Active Descendant", () => {
   afterEach(async () => {

--- a/test/int/ariaActiveDescendantCombobox.int.test.ts
+++ b/test/int/ariaActiveDescendantCombobox.int.test.ts
@@ -1,5 +1,5 @@
-import { setupComboboxWithListAutocomplete } from './comboboxWithListAutocomplete.js';
-import { virtual } from '../../src/index.js';
+import { setupComboboxWithListAutocomplete } from "./comboboxWithListAutocomplete.js";
+import { virtual } from "../../src/index.js";
 
 describe("Aria Active Descendant", () => {
   let teardown;

--- a/test/int/ariaActiveDescendantMenuButton1.int.test.ts
+++ b/test/int/ariaActiveDescendantMenuButton1.int.test.ts
@@ -1,5 +1,5 @@
-import { setupActionsMenuButton } from './actionsMenuButton.js';
-import { virtual } from '../../src/index.js';
+import { setupActionsMenuButton } from "./actionsMenuButton.js";
+import { virtual } from "../../src/index.js";
 
 describe("Aria Active Descendant Menu Button", () => {
   let teardown;

--- a/test/int/ariaActiveDescendantMenuButton2.int.test.ts
+++ b/test/int/ariaActiveDescendantMenuButton2.int.test.ts
@@ -1,5 +1,5 @@
-import { setupActionsMenuButton } from './actionsMenuButton.js';
-import { virtual } from '../../src/index.js';
+import { setupActionsMenuButton } from "./actionsMenuButton.js";
+import { virtual } from "../../src/index.js";
 
 describe("Aria Active Descendant Menu Button", () => {
   let teardown;

--- a/test/int/ariaAtomic.int.test.ts
+++ b/test/int/ariaAtomic.int.test.ts
@@ -1,6 +1,6 @@
 import { screen, waitFor } from "@testing-library/dom";
-import { setupAriaAtomic } from './ariaAtomic.js';
-import { virtual } from '../../src/index.js';
+import { setupAriaAtomic } from "./ariaAtomic.js";
+import { virtual } from "../../src/index.js";
 
 describe("Aria Atomic", () => {
   let teardown;

--- a/test/int/ariaDetails.int.test.ts
+++ b/test/int/ariaDetails.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 
 describe("Aria Details", () => {
   afterEach(async () => {

--- a/test/int/ariaErrorMessage.int.test.ts
+++ b/test/int/ariaErrorMessage.int.test.ts
@@ -27,21 +27,21 @@ describe("Aria Error Message", () => {
     document.body.innerHTML = "";
   });
 
-  it("should not convey the error when the error message is NOT pertinent - applied to the input[type=\"text\"] element", async () => {
+  it('should not convey the error when the error message is NOT pertinent - applied to the input[type="text"] element', async () => {
     document.querySelector<HTMLInputElement>("#invalid-false")!.focus();
 
     expect(await virtual.spokenPhraseLog()).toEqual([
       "document",
-      "textbox, Input with aria-invalid=\"false\", not invalid",
+      'textbox, Input with aria-invalid="false", not invalid',
     ]);
   });
 
-  it("should convey that the referenced error message is pertinent - applied to the input[type=\"text\"] element", async () => {
+  it('should convey that the referenced error message is pertinent - applied to the input[type="text"] element', async () => {
     document.querySelector<HTMLInputElement>("#invalid-true")!.focus();
 
     expect(await virtual.spokenPhraseLog()).toEqual([
       "document",
-      "textbox, Input with aria-invalid=\"true\", 1 error message, invalid",
+      'textbox, Input with aria-invalid="true", 1 error message, invalid',
     ]);
   });
 });

--- a/test/int/ariaErrorMessage.int.test.ts
+++ b/test/int/ariaErrorMessage.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 
 describe("Aria Error Message", () => {
   beforeEach(async () => {
@@ -24,24 +24,24 @@ describe("Aria Error Message", () => {
 
   afterEach(async () => {
     await virtual.stop();
-    document.body.innerHTML = ``;
+    document.body.innerHTML = "";
   });
 
-  it('should not convey the error when the error message is NOT pertinent - applied to the input[type="text"] element', async () => {
+  it("should not convey the error when the error message is NOT pertinent - applied to the input[type=\"text\"] element", async () => {
     document.querySelector<HTMLInputElement>("#invalid-false")!.focus();
 
     expect(await virtual.spokenPhraseLog()).toEqual([
       "document",
-      'textbox, Input with aria-invalid="false", not invalid',
+      "textbox, Input with aria-invalid=\"false\", not invalid",
     ]);
   });
 
-  it('should convey that the referenced error message is pertinent - applied to the input[type="text"] element', async () => {
+  it("should convey that the referenced error message is pertinent - applied to the input[type=\"text\"] element", async () => {
     document.querySelector<HTMLInputElement>("#invalid-true")!.focus();
 
     expect(await virtual.spokenPhraseLog()).toEqual([
       "document",
-      'textbox, Input with aria-invalid="true", 1 error message, invalid',
+      "textbox, Input with aria-invalid=\"true\", 1 error message, invalid",
     ]);
   });
 });

--- a/test/int/ariaFlowTo.int.test.ts
+++ b/test/int/ariaFlowTo.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 
 describe("Aria Flow To", () => {
   afterEach(async () => {

--- a/test/int/ariaLive.int.test.ts
+++ b/test/int/ariaLive.int.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { setupAriaLive } from './ariaLive.js';
-import { virtual } from '../../src/index.js';
+import { setupAriaLive } from "./ariaLive.js";
+import { virtual } from "../../src/index.js";
 import { waitFor } from "@testing-library/dom";
 
 describe("Aria Live", () => {

--- a/test/int/ariaLive2.int.test.ts
+++ b/test/int/ariaLive2.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 import { waitFor } from "@testing-library/dom";
 
 describe("Aria Live - Content Editable", () => {
@@ -12,7 +12,7 @@ describe("Aria Live - Content Editable", () => {
 
   afterEach(async () => {
     await virtual.stop();
-    document.body.innerHTML = ``;
+    document.body.innerHTML = "";
   });
 
   it("should announce changes to a live region - applied to the contenteditable element", async () => {
@@ -62,7 +62,7 @@ describe("Aria Live - All Attributes", () => {
 
   afterEach(async () => {
     await virtual.stop();
-    document.body.innerHTML = ``;
+    document.body.innerHTML = "";
   });
 
   it("should announce changes to a live region - all attributes short-circuit", async () => {

--- a/test/int/ariaOwns.int.test.ts
+++ b/test/int/ariaOwns.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 
 describe("Aria Owns", () => {
   afterEach(async () => {

--- a/test/int/ariaPlaceholder.int.test.ts
+++ b/test/int/ariaPlaceholder.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 
 describe("Placeholder Attribute Property", () => {
   afterEach(async () => {

--- a/test/int/ariaReadonly.int.test.ts
+++ b/test/int/ariaReadonly.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 
 describe("Read only Attribute State", () => {
   afterEach(async () => {

--- a/test/int/ariaRelevant.int.test.ts
+++ b/test/int/ariaRelevant.int.test.ts
@@ -1,6 +1,6 @@
 import { screen, waitFor } from "@testing-library/dom";
-import { setupAriaRelevant } from './ariaRelevant.js';
-import { virtual } from '../../src/index.js';
+import { setupAriaRelevant } from "./ariaRelevant.js";
+import { virtual } from "../../src/index.js";
 
 describe("Aria Relevant", () => {
   let teardown;

--- a/test/int/ariaRelevant.js
+++ b/test/int/ariaRelevant.js
@@ -12,7 +12,7 @@ function test(index) {
 }
 
 function setupAriaRelevant() {
-  document.body.innerHTML = `<div id="content"></div>`;
+  document.body.innerHTML = "<div id=\"content\"></div>";
 
   [null, "", "additions", "removals", "text", "all", "additions text"].forEach(
     function (attr, index) {

--- a/test/int/ariaRelevant.js
+++ b/test/int/ariaRelevant.js
@@ -12,7 +12,7 @@ function test(index) {
 }
 
 function setupAriaRelevant() {
-  document.body.innerHTML = "<div id=\"content\"></div>";
+  document.body.innerHTML = '<div id="content"></div>';
 
   [null, "", "additions", "removals", "text", "all", "additions text"].forEach(
     function (attr, index) {

--- a/test/int/ariaRoleDescription.int.test.ts
+++ b/test/int/ariaRoleDescription.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 
 describe("Aria Role Description", () => {
   afterEach(async () => {

--- a/test/int/ariaValueNow.int.test.ts
+++ b/test/int/ariaValueNow.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 
 describe("Label Priority Replacement", () => {
   afterEach(async () => {

--- a/test/int/checked.int.test.ts
+++ b/test/int/checked.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 
 describe("Checked Attribute State", () => {
   afterEach(async () => {

--- a/test/int/click.int.test.ts
+++ b/test/int/click.int.test.ts
@@ -1,5 +1,5 @@
 import { getByText, queryByText } from "@testing-library/dom";
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 
 function setupButtonPage() {
   document.body.innerHTML = `
@@ -22,7 +22,7 @@ function setupButtonPage() {
 
   document.body.addEventListener("contextmenu", () => {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    document.getElementById("status")!.innerHTML = `Right Clicked`;
+    document.getElementById("status")!.innerHTML = "Right Clicked";
   });
 }
 

--- a/test/int/comboboxWithListAutocomplete.js
+++ b/test/int/comboboxWithListAutocomplete.js
@@ -675,7 +675,7 @@ function setupComboboxWithListAutocomplete() {
       var combobox = comboboxes[i];
       var comboboxNode = combobox.querySelector("input");
       var buttonNode = combobox.querySelector("button");
-      var listboxNode = combobox.querySelector("[role=\"listbox\"]");
+      var listboxNode = combobox.querySelector('[role="listbox"]');
       new ComboboxAutocomplete(comboboxNode, buttonNode, listboxNode);
     }
   }

--- a/test/int/comboboxWithListAutocomplete.js
+++ b/test/int/comboboxWithListAutocomplete.js
@@ -675,7 +675,7 @@ function setupComboboxWithListAutocomplete() {
       var combobox = comboboxes[i];
       var comboboxNode = combobox.querySelector("input");
       var buttonNode = combobox.querySelector("button");
-      var listboxNode = combobox.querySelector('[role="listbox"]');
+      var listboxNode = combobox.querySelector("[role=\"listbox\"]");
       new ComboboxAutocomplete(comboboxNode, buttonNode, listboxNode);
     }
   }

--- a/test/int/containerHidden.int.test.ts
+++ b/test/int/containerHidden.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 
 describe("Container Hidden", () => {
   beforeEach(async () => {

--- a/test/int/detection.int.test.ts
+++ b/test/int/detection.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 
 describe("Detection", () => {
   it("should return true for Virtual being a supported screen reader for the OS", async () => {

--- a/test/int/dialog.int.test.ts
+++ b/test/int/dialog.int.test.ts
@@ -1,5 +1,5 @@
 import { screen } from "@testing-library/dom";
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 
 function setupDialogPage() {
   document.body.innerHTML = `

--- a/test/int/disabled.int.test.ts
+++ b/test/int/disabled.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 
 describe("Disabled Attribute State", () => {
   afterEach(async () => {

--- a/test/int/edgeCaseContainer.test.ts
+++ b/test/int/edgeCaseContainer.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 
 describe("Edge Case Container", () => {
   afterEach(async () => {

--- a/test/int/focus.int.test.ts
+++ b/test/int/focus.int.test.ts
@@ -1,5 +1,5 @@
 import { getByText } from "@testing-library/dom";
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 
 function setupFocusChangePage() {
   document.body.innerHTML = `

--- a/test/int/implicitAriaStates.int.test.ts
+++ b/test/int/implicitAriaStates.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 
 describe("Implicit Aria States", () => {
   afterEach(async () => {

--- a/test/int/inheritedImplicitPresentational.int.test.ts
+++ b/test/int/inheritedImplicitPresentational.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 
 describe("Inherited Implicit Presentational Role", () => {
   afterEach(async () => {

--- a/test/int/interact.int.test.ts
+++ b/test/int/interact.int.test.ts
@@ -1,5 +1,5 @@
-import { setupBasicPage } from '../utils.js';
-import { virtual } from '../../src/index.js';
+import { setupBasicPage } from "../utils.js";
+import { virtual } from "../../src/index.js";
 
 describe("interact / stopInteracting", () => {
   beforeEach(() => {

--- a/test/int/invalidStart.test.ts
+++ b/test/int/invalidStart.test.ts
@@ -1,8 +1,8 @@
 import {
   ERR_VIRTUAL_MISSING_CONTAINER,
   ERR_VIRTUAL_NOT_STARTED,
-} from '../../src/errors.js';
-import { virtual } from '../../src/index.js';
+} from "../../src/errors.js";
+import { virtual } from "../../src/index.js";
 
 describe("Invalid Start", () => {
   beforeEach(() => {

--- a/test/int/jumpToControlledElement.int.test.ts
+++ b/test/int/jumpToControlledElement.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 
 describe("jumpToControlledElement", () => {
   afterEach(async () => {
@@ -133,7 +133,7 @@ describe("jumpToControlledElement", () => {
   });
 
   it("should ignore the command on a non-element node", async () => {
-    document.body.innerHTML = `Hello World`;
+    document.body.innerHTML = "Hello World";
 
     await virtual.start({ container: document.body });
     await virtual.next();

--- a/test/int/jumpToDetailsElement.int.test.ts
+++ b/test/int/jumpToDetailsElement.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 
 describe("jumpToDetailsElement", () => {
   afterEach(async () => {
@@ -77,7 +77,7 @@ describe("jumpToDetailsElement", () => {
   });
 
   it("should ignore the command on a non-element node", async () => {
-    document.body.innerHTML = `Hello World`;
+    document.body.innerHTML = "Hello World";
 
     await virtual.start({ container: document.body });
     await virtual.next();

--- a/test/int/jumpToErrorMessageElement.int.test.ts
+++ b/test/int/jumpToErrorMessageElement.int.test.ts
@@ -20,8 +20,8 @@ describe("jumpToErrorMessageElement", () => {
 
     expect(await virtual.spokenPhraseLog()).toEqual([
       "document",
-      "Input with aria-invalid=\"true\"",
-      "textbox, Input with aria-invalid=\"true\", 1 error message, invalid",
+      'Input with aria-invalid="true"',
+      'textbox, Input with aria-invalid="true", 1 error message, invalid',
       "example error text",
     ]);
   });
@@ -43,8 +43,8 @@ describe("jumpToErrorMessageElement", () => {
 
     expect(await virtual.spokenPhraseLog()).toEqual([
       "document",
-      "Input with aria-invalid=\"true\"",
-      "textbox, Input with aria-invalid=\"true\", 2 error messages, invalid",
+      'Input with aria-invalid="true"',
+      'textbox, Input with aria-invalid="true", 2 error messages, invalid',
       "second example error text",
     ]);
   });
@@ -64,8 +64,8 @@ describe("jumpToErrorMessageElement", () => {
 
     expect(await virtual.spokenPhraseLog()).toEqual([
       "document",
-      "Input with aria-invalid=\"true\"",
-      "textbox, Input with aria-invalid=\"true\", 2 error messages, invalid",
+      'Input with aria-invalid="true"',
+      'textbox, Input with aria-invalid="true", 2 error messages, invalid',
       "first example error text",
     ]);
   });
@@ -87,8 +87,8 @@ describe("jumpToErrorMessageElement", () => {
 
     expect(await virtual.spokenPhraseLog()).toEqual([
       "document",
-      "Input with aria-invalid=\"true\"",
-      "textbox, Input with aria-invalid=\"true\", 2 error messages, invalid",
+      'Input with aria-invalid="true"',
+      'textbox, Input with aria-invalid="true", 2 error messages, invalid',
       "second example error text",
     ]);
   });
@@ -161,8 +161,8 @@ describe("jumpToErrorMessageElement", () => {
 
     expect(await virtual.spokenPhraseLog()).toEqual([
       "document",
-      "Input with aria-invalid=\"true\"",
-      "textbox, Input with aria-invalid=\"true\", invalid",
+      'Input with aria-invalid="true"',
+      'textbox, Input with aria-invalid="true", invalid',
     ]);
 
     await virtual.stop();
@@ -182,8 +182,8 @@ describe("jumpToErrorMessageElement", () => {
 
     expect(await virtual.spokenPhraseLog()).toEqual([
       "document",
-      "Input with aria-invalid=\"true\"",
-      "textbox, Input with aria-invalid=\"true\", 1 error message, invalid",
+      'Input with aria-invalid="true"',
+      'textbox, Input with aria-invalid="true", 1 error message, invalid',
     ]);
   });
 });

--- a/test/int/jumpToErrorMessageElement.int.test.ts
+++ b/test/int/jumpToErrorMessageElement.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 
 describe("jumpToErrorMessageElement", () => {
   afterEach(async () => {
@@ -20,8 +20,8 @@ describe("jumpToErrorMessageElement", () => {
 
     expect(await virtual.spokenPhraseLog()).toEqual([
       "document",
-      'Input with aria-invalid="true"',
-      'textbox, Input with aria-invalid="true", 1 error message, invalid',
+      "Input with aria-invalid=\"true\"",
+      "textbox, Input with aria-invalid=\"true\", 1 error message, invalid",
       "example error text",
     ]);
   });
@@ -43,8 +43,8 @@ describe("jumpToErrorMessageElement", () => {
 
     expect(await virtual.spokenPhraseLog()).toEqual([
       "document",
-      'Input with aria-invalid="true"',
-      'textbox, Input with aria-invalid="true", 2 error messages, invalid',
+      "Input with aria-invalid=\"true\"",
+      "textbox, Input with aria-invalid=\"true\", 2 error messages, invalid",
       "second example error text",
     ]);
   });
@@ -64,8 +64,8 @@ describe("jumpToErrorMessageElement", () => {
 
     expect(await virtual.spokenPhraseLog()).toEqual([
       "document",
-      'Input with aria-invalid="true"',
-      'textbox, Input with aria-invalid="true", 2 error messages, invalid',
+      "Input with aria-invalid=\"true\"",
+      "textbox, Input with aria-invalid=\"true\", 2 error messages, invalid",
       "first example error text",
     ]);
   });
@@ -87,8 +87,8 @@ describe("jumpToErrorMessageElement", () => {
 
     expect(await virtual.spokenPhraseLog()).toEqual([
       "document",
-      'Input with aria-invalid="true"',
-      'textbox, Input with aria-invalid="true", 2 error messages, invalid',
+      "Input with aria-invalid=\"true\"",
+      "textbox, Input with aria-invalid=\"true\", 2 error messages, invalid",
       "second example error text",
     ]);
   });
@@ -117,7 +117,7 @@ describe("jumpToErrorMessageElement", () => {
   });
 
   it("should ignore the command on a non-element node", async () => {
-    document.body.innerHTML = `Hello World`;
+    document.body.innerHTML = "Hello World";
 
     await virtual.start({ container: document.body });
     await virtual.next();
@@ -161,8 +161,8 @@ describe("jumpToErrorMessageElement", () => {
 
     expect(await virtual.spokenPhraseLog()).toEqual([
       "document",
-      'Input with aria-invalid="true"',
-      'textbox, Input with aria-invalid="true", invalid',
+      "Input with aria-invalid=\"true\"",
+      "textbox, Input with aria-invalid=\"true\", invalid",
     ]);
 
     await virtual.stop();
@@ -182,8 +182,8 @@ describe("jumpToErrorMessageElement", () => {
 
     expect(await virtual.spokenPhraseLog()).toEqual([
       "document",
-      'Input with aria-invalid="true"',
-      'textbox, Input with aria-invalid="true", 1 error message, invalid',
+      "Input with aria-invalid=\"true\"",
+      "textbox, Input with aria-invalid=\"true\", 1 error message, invalid",
     ]);
   });
 });

--- a/test/int/labelPriorityReplacement.int.test.ts
+++ b/test/int/labelPriorityReplacement.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 
 describe("Label Priority Replacement", () => {
   afterEach(async () => {

--- a/test/int/liveRegionRoles.int.test.ts
+++ b/test/int/liveRegionRoles.int.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { setupLiveRegionRoles } from './liveRegionRoles.js';
-import { virtual } from '../../src/index.js';
+import { setupLiveRegionRoles } from "./liveRegionRoles.js";
+import { virtual } from "../../src/index.js";
 import { waitFor } from "@testing-library/dom";
 
 describe("Live Region Roles", () => {

--- a/test/int/moveToHeading.int.test.ts
+++ b/test/int/moveToHeading.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 
 const headingLevels = ["1", "2", "3", "4", "5", "6"];
 
@@ -31,12 +31,12 @@ describe("Move To Heading", () => {
         const spokenPhraseLog = await virtual.spokenPhraseLog();
         expect(spokenPhraseLog).toEqual([
           "document",
-          `heading, Heading Level 1, level 1`,
-          `heading, Heading Level 2, level 2`,
-          `heading, Heading Level 3, level 3`,
-          `heading, Heading Level 4, level 4`,
-          `heading, Heading Level 5, level 5`,
-          `heading, Heading Level 6, level 6`,
+          "heading, Heading Level 1, level 1",
+          "heading, Heading Level 2, level 2",
+          "heading, Heading Level 3, level 3",
+          "heading, Heading Level 4, level 4",
+          "heading, Heading Level 5, level 5",
+          "heading, Heading Level 6, level 6",
         ]);
       });
     });
@@ -72,18 +72,18 @@ describe("Move To Heading", () => {
         const spokenPhraseLog = await virtual.spokenPhraseLog();
         expect(spokenPhraseLog).toEqual([
           "document",
-          `heading, Heading Level 1, level 1`,
-          `heading, Heading Level 2, level 2`,
-          `heading, Heading Level 3, level 3`,
-          `heading, Heading Level 4, level 4`,
-          `heading, Heading Level 5, level 5`,
-          `heading, Heading Level 6, level 6`,
-          `heading, Heading Level 7, level 7`,
-          `heading, Heading Level 8, level 8`,
-          `heading, Heading Level 9, level 9`,
-          `heading, Heading Level 10, level 10`,
-          `heading, Heading Level 11, level 11`,
-          `heading, Heading Level 12, level 12`,
+          "heading, Heading Level 1, level 1",
+          "heading, Heading Level 2, level 2",
+          "heading, Heading Level 3, level 3",
+          "heading, Heading Level 4, level 4",
+          "heading, Heading Level 5, level 5",
+          "heading, Heading Level 6, level 6",
+          "heading, Heading Level 7, level 7",
+          "heading, Heading Level 8, level 8",
+          "heading, Heading Level 9, level 9",
+          "heading, Heading Level 10, level 10",
+          "heading, Heading Level 11, level 11",
+          "heading, Heading Level 12, level 12",
         ]);
       });
     });
@@ -128,12 +128,12 @@ describe("Move To Heading", () => {
         const spokenPhraseLog = await virtual.spokenPhraseLog();
         expect(spokenPhraseLog).toEqual([
           "document",
-          `heading, Heading Level 6, level 6`,
-          `heading, Heading Level 5, level 5`,
-          `heading, Heading Level 4, level 4`,
-          `heading, Heading Level 3, level 3`,
-          `heading, Heading Level 2, level 2`,
-          `heading, Heading Level 1, level 1`,
+          "heading, Heading Level 6, level 6",
+          "heading, Heading Level 5, level 5",
+          "heading, Heading Level 4, level 4",
+          "heading, Heading Level 3, level 3",
+          "heading, Heading Level 2, level 2",
+          "heading, Heading Level 1, level 1",
         ]);
       });
     });
@@ -171,18 +171,18 @@ describe("Move To Heading", () => {
         const spokenPhraseLog = await virtual.spokenPhraseLog();
         expect(spokenPhraseLog).toEqual([
           "document",
-          `heading, Heading Level 12, level 12`,
-          `heading, Heading Level 11, level 11`,
-          `heading, Heading Level 10, level 10`,
-          `heading, Heading Level 9, level 9`,
-          `heading, Heading Level 8, level 8`,
-          `heading, Heading Level 7, level 7`,
-          `heading, Heading Level 6, level 6`,
-          `heading, Heading Level 5, level 5`,
-          `heading, Heading Level 4, level 4`,
-          `heading, Heading Level 3, level 3`,
-          `heading, Heading Level 2, level 2`,
-          `heading, Heading Level 1, level 1`,
+          "heading, Heading Level 12, level 12",
+          "heading, Heading Level 11, level 11",
+          "heading, Heading Level 10, level 10",
+          "heading, Heading Level 9, level 9",
+          "heading, Heading Level 8, level 8",
+          "heading, Heading Level 7, level 7",
+          "heading, Heading Level 6, level 6",
+          "heading, Heading Level 5, level 5",
+          "heading, Heading Level 4, level 4",
+          "heading, Heading Level 3, level 3",
+          "heading, Heading Level 2, level 2",
+          "heading, Heading Level 1, level 1",
         ]);
       });
     });

--- a/test/int/moveToRole.int.test.ts
+++ b/test/int/moveToRole.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 
 const quickNavigationRoles = [
   "banner",

--- a/test/int/next.int.test.ts
+++ b/test/int/next.int.test.ts
@@ -1,6 +1,6 @@
 import { getByRole } from "@testing-library/dom";
-import { setupBasicPage } from '../utils.js';
-import { virtual } from '../../src/index.js';
+import { setupBasicPage } from "../utils.js";
+import { virtual } from "../../src/index.js";
 
 describe("next", () => {
   beforeEach(async () => {

--- a/test/int/nodeEnvironment.int.test.ts
+++ b/test/int/nodeEnvironment.int.test.ts
@@ -1,0 +1,165 @@
+/**
+ * @jest-environment node
+ */
+/* eslint-disable no-global-assign */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { TextDecoder, TextEncoder } from "util";
+Object.assign(global, { TextDecoder, TextEncoder });
+
+import jsdom from "jsdom";
+import { virtual } from "../../src/index.js";
+import { waitFor } from "@testing-library/dom";
+
+describe("Node Environment", () => {
+  let dom: jsdom.JSDOM;
+
+  beforeEach(() => {
+    globalThis.window = undefined as any;
+
+    const { JSDOM } = jsdom;
+
+    dom = new JSDOM(
+      `<!DOCTYPE html>
+<html>
+  <head></head>
+  <body>
+    <nav>Nav Text</nav>
+    <main>
+      <p id="target" contenteditable="true" aria-live="polite">Edit this text!</p>
+    </main>
+    <footer>Footer</footer>
+  </body>
+</html>`
+    );
+  });
+
+  afterEach(async () => {
+    await virtual.stop();
+
+    // Some hackery to ensure Testing Library jest-dom helpers don't fall over
+    // as they expect window.navigator to be defined for some clipboard cleanup
+    // in some global afterAll hooks they add to jest.
+    globalThis.window = {
+      navigator: {} as any,
+    } as any;
+  });
+
+  describe("when no window global is provided", () => {
+    beforeEach(async () => {
+      await virtual.start({
+        container: dom.window.document.body,
+        window: undefined,
+      });
+    });
+
+    it("should handle commands gracefully", async () => {
+      while ((await virtual.lastSpokenPhrase()) !== "end of document") {
+        await virtual.next();
+      }
+
+      expect(await virtual.itemTextLog()).toEqual([
+        "",
+        "",
+        "Nav Text",
+        "",
+        "",
+        "Edit this text!",
+        "",
+        "",
+        "Footer",
+        "",
+        "",
+      ]);
+
+      expect(await virtual.spokenPhraseLog()).toEqual([
+        "document",
+        "navigation",
+        "Nav Text",
+        "end of navigation",
+        "main",
+        "Edit this text!",
+        "end of main",
+        "contentinfo",
+        "Footer",
+        "end of contentinfo",
+        "end of document",
+      ]);
+    });
+
+    it("should handle live regions gracefully without observing nor announcing the live region changes", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      dom.window.document.querySelector("#target")!.textContent = "Updated";
+
+      await waitFor(
+        () =>
+          expect(
+            dom.window.document.querySelector("#target")?.textContent
+          ).toBe("Updated"),
+        { container: dom.window.document.body, timeout: 7000 }
+      );
+
+      expect(await virtual.spokenPhraseLog()).toEqual(["document"]);
+    });
+  });
+
+  describe("when a window global is provided", () => {
+    beforeEach(async () => {
+      await virtual.start({
+        container: dom.window.document.body,
+        window: dom.window,
+      });
+    });
+
+    it("should handle commands gracefully", async () => {
+      while ((await virtual.lastSpokenPhrase()) !== "end of document") {
+        await virtual.next();
+      }
+
+      expect(await virtual.itemTextLog()).toEqual([
+        "",
+        "",
+        "Nav Text",
+        "",
+        "",
+        "Edit this text!",
+        "",
+        "",
+        "Footer",
+        "",
+        "",
+      ]);
+
+      expect(await virtual.spokenPhraseLog()).toEqual([
+        "document",
+        "navigation",
+        "Nav Text",
+        "end of navigation",
+        "main",
+        "Edit this text!",
+        "end of main",
+        "contentinfo",
+        "Footer",
+        "end of contentinfo",
+        "end of document",
+      ]);
+    });
+
+    it("should handle live regions gracefully", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      dom.window.document.querySelector("#target")!.textContent = "Updated";
+
+      await waitFor(
+        () =>
+          expect(
+            dom.window.document.querySelector("#target")?.textContent
+          ).toBe("Updated"),
+        { container: dom.window.document.body, timeout: 7000 }
+      );
+
+      expect(await virtual.spokenPhraseLog()).toEqual([
+        "document",
+        "polite: Updated",
+      ]);
+    });
+  });
+});

--- a/test/int/press.int.test.ts
+++ b/test/int/press.int.test.ts
@@ -1,5 +1,5 @@
 import { getByRole } from "@testing-library/dom";
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 
 function setupInputPage() {
   document.body.innerHTML = `

--- a/test/int/pressed.int.test.ts
+++ b/test/int/pressed.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 
 describe("Checked Attribute State", () => {
   afterEach(async () => {

--- a/test/int/previous.int.test.ts
+++ b/test/int/previous.int.test.ts
@@ -1,6 +1,6 @@
 import { getByRole } from "@testing-library/dom";
-import { setupBasicPage } from '../utils.js';
-import { virtual } from '../../src/index.js';
+import { setupBasicPage } from "../utils.js";
+import { virtual } from "../../src/index.js";
 
 describe("previous", () => {
   beforeEach(async () => {

--- a/test/int/reactUseId.int.test.tsx
+++ b/test/int/reactUseId.int.test.tsx
@@ -1,6 +1,6 @@
 import React, { useId } from "react";
 import { render } from "@testing-library/react";
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 
 const ComponentWithReactUseId = () => {
   const childId = useId();

--- a/test/int/type.int.test.ts
+++ b/test/int/type.int.test.ts
@@ -1,5 +1,5 @@
 import { getByRole } from "@testing-library/dom";
-import { virtual } from '../../src/index.js';
+import { virtual } from "../../src/index.js";
 
 function setupInputPage() {
   document.body.innerHTML = `

--- a/test/wpt/accname/basic.int.test.ts
+++ b/test/wpt/accname/basic.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../src/index.js';
+import { virtual } from "../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/accname/basic.html

--- a/test/wpt/accname/manual/description_1.0_combobox-focusable-manual.int.test.ts
+++ b/test/wpt/accname/manual/description_1.0_combobox-focusable-manual.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../../src/index.js';
+import { virtual } from "../../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/accname/manual/description_1.0_combobox-focusable-manual.html

--- a/test/wpt/accname/manual/description_from_content_of_describedby_element-manual.int.test.ts
+++ b/test/wpt/accname/manual/description_from_content_of_describedby_element-manual.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../../src/index.js';
+import { virtual } from "../../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/accname/manual/description_from_content_of_describedby_element-manual.html

--- a/test/wpt/accname/manual/description_link-with-label-manual.int.test.ts
+++ b/test/wpt/accname/manual/description_link-with-label-manual.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../../src/index.js';
+import { virtual } from "../../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/accname/manual/description_link-with-label-manual.html

--- a/test/wpt/accname/manual/description_test_case_557-manual.int.test.ts
+++ b/test/wpt/accname/manual/description_test_case_557-manual.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../../src/index.js';
+import { virtual } from "../../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/accname/manual/description_test_case_557-manual.html

--- a/test/wpt/accname/manual/description_test_case_664-manual.int.test.ts
+++ b/test/wpt/accname/manual/description_test_case_664-manual.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../../src/index.js';
+import { virtual } from "../../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/accname/manual/description_test_case_664-manual.html

--- a/test/wpt/accname/manual/description_test_case_665-manual.int.test.ts
+++ b/test/wpt/accname/manual/description_test_case_665-manual.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../../src/index.js';
+import { virtual } from "../../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/accname/manual/description_test_case_665-manual.html

--- a/test/wpt/accname/manual/description_test_case_666-manual.int.test.ts
+++ b/test/wpt/accname/manual/description_test_case_666-manual.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../../src/index.js';
+import { virtual } from "../../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/accname/manual/description_test_case_666-manual.html

--- a/test/wpt/accname/manual/description_test_case_772-manual.int.test.ts
+++ b/test/wpt/accname/manual/description_test_case_772-manual.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../../src/index.js';
+import { virtual } from "../../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/accname/manual/description_test_case_772-manual.html

--- a/test/wpt/accname/manual/description_test_case_773-manual.int.test.ts
+++ b/test/wpt/accname/manual/description_test_case_773-manual.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../../src/index.js';
+import { virtual } from "../../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/accname/manual/description_test_case_773-manual.html

--- a/test/wpt/accname/manual/description_test_case_774-manual.int.test.ts
+++ b/test/wpt/accname/manual/description_test_case_774-manual.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../../src/index.js';
+import { virtual } from "../../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/accname/manual/description_test_case_774-manual.html

--- a/test/wpt/accname/manual/description_test_case_838-manual.int.test.ts
+++ b/test/wpt/accname/manual/description_test_case_838-manual.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../../src/index.js';
+import { virtual } from "../../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/accname/manual/description_test_case_838-manual.html

--- a/test/wpt/accname/manual/description_test_case_broken_reference-manual.int.test.ts
+++ b/test/wpt/accname/manual/description_test_case_broken_reference-manual.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../../src/index.js';
+import { virtual } from "../../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/accname/manual/description_test_case_broken_reference-manual.html

--- a/test/wpt/accname/manual/description_test_case_one_valid_reference-manual.int.test.ts
+++ b/test/wpt/accname/manual/description_test_case_one_valid_reference-manual.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../../src/index.js';
+import { virtual } from "../../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/accname/manual/description_test_case_one_valid_reference-manual.html

--- a/test/wpt/accname/manual/description_title-same-element-manual.int.test.ts
+++ b/test/wpt/accname/manual/description_title-same-element-manual.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../../src/index.js';
+import { virtual } from "../../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/accname/manual/description_title-same-element-manual.html

--- a/test/wpt/accname/name/comp_embedded_control.int.test.ts
+++ b/test/wpt/accname/name/comp_embedded_control.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../../src/index.js';
+import { virtual } from "../../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/accname/name/comp_embedded_control.html

--- a/test/wpt/accname/name/comp_hidden_not_referenced.int.test.ts
+++ b/test/wpt/accname/name/comp_hidden_not_referenced.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../../src/index.js';
+import { virtual } from "../../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/accname/name/comp_hidden_not_referenced.html

--- a/test/wpt/accname/name/comp_host_language_label.int.test.ts
+++ b/test/wpt/accname/name/comp_host_language_label.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../../src/index.js';
+import { virtual } from "../../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/accname/name/comp_host_language_label.html

--- a/test/wpt/accname/name/comp_label.int.test.ts
+++ b/test/wpt/accname/name/comp_label.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../../src/index.js';
+import { virtual } from "../../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/accname/name/comp_label.html

--- a/test/wpt/accname/name/comp_labelledby.int.test.ts
+++ b/test/wpt/accname/name/comp_labelledby.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../../src/index.js';
+import { virtual } from "../../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/accname/name/comp_labelledby.html

--- a/test/wpt/accname/name/comp_name_from_content.int.test.ts
+++ b/test/wpt/accname/name/comp_name_from_content.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../../src/index.js';
+import { virtual } from "../../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/accname/name/comp_name_from_content.html

--- a/test/wpt/accname/name/comp_text_node.int.test.ts
+++ b/test/wpt/accname/name/comp_text_node.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../../src/index.js';
+import { virtual } from "../../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/accname/name/comp_text_node.html

--- a/test/wpt/html-aam/roles.int.test.ts
+++ b/test/wpt/html-aam/roles.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../src/index.js';
+import { virtual } from "../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/html-aam/roles.html

--- a/test/wpt/html-aam/table-roles.int.test.ts
+++ b/test/wpt/html-aam/table-roles.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../src/index.js';
+import { virtual } from "../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/html-aam/table-roles.html

--- a/test/wpt/wai-aria/role/abstract-roles.int.test.ts
+++ b/test/wpt/wai-aria/role/abstract-roles.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../../src/index.js';
+import { virtual } from "../../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/wai-aria/role/abstract-roles.html

--- a/test/wpt/wai-aria/role/basic.int.test.ts
+++ b/test/wpt/wai-aria/role/basic.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../../src/index.js';
+import { virtual } from "../../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/wai-aria/role/basic.html

--- a/test/wpt/wai-aria/role/fallback-roles.int.test.ts
+++ b/test/wpt/wai-aria/role/fallback-roles.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../../src/index.js';
+import { virtual } from "../../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/wai-aria/role/fallback-roles.html

--- a/test/wpt/wai-aria/role/form-roles.int.test.ts
+++ b/test/wpt/wai-aria/role/form-roles.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../../src/index.js';
+import { virtual } from "../../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/wai-aria/role/form-roles.html

--- a/test/wpt/wai-aria/role/invalid-roles.int.test.ts
+++ b/test/wpt/wai-aria/role/invalid-roles.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../../src/index.js';
+import { virtual } from "../../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/wai-aria/role/invalid-roles.html

--- a/test/wpt/wai-aria/role/list-roles.int.test.ts
+++ b/test/wpt/wai-aria/role/list-roles.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../../src/index.js';
+import { virtual } from "../../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/wai-aria/role/list-roles.html

--- a/test/wpt/wai-aria/role/region-roles.int.test.ts
+++ b/test/wpt/wai-aria/role/region-roles.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../../src/index.js';
+import { virtual } from "../../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/wai-aria/role/region-roles.html

--- a/test/wpt/wai-aria/role/role_non_conflict_resolution.int.test.ts
+++ b/test/wpt/wai-aria/role/role_non_conflict_resolution.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../../src/index.js';
+import { virtual } from "../../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/wai-aria/role/role_none_conflict_resolution.html

--- a/test/wpt/wai-aria/role/roles.int.test.ts
+++ b/test/wpt/wai-aria/role/roles.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../../src/index.js';
+import { virtual } from "../../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/wai-aria/role/roles.html

--- a/test/wpt/wai-aria/role/synonym-roles.int.test.ts
+++ b/test/wpt/wai-aria/role/synonym-roles.int.test.ts
@@ -1,4 +1,4 @@
-import { virtual } from '../../../../src/index.js';
+import { virtual } from "../../../../src/index.js";
 
 /**
  * https://github.com/web-platform-tests/wpt/blob/master/wai-aria/role/synonym-roles.html

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "rootDir": "./test",
     "target": "esnext",
-  }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "test/**/*.ts"],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1193,6 +1193,13 @@ agent-base@6:
   dependencies:
     debug "4"
 
+agent-base@^7.0.2, agent-base@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.0.tgz#536802b76bc0b34aa50195eb2442276d613e3434"
+  integrity sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==
+  dependencies:
+    debug "^4.3.4"
+
 ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -1631,6 +1638,13 @@ cssstyle@^2.3.0:
   dependencies:
     cssom "~0.3.6"
 
+cssstyle@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-4.0.1.tgz#ef29c598a1e90125c870525490ea4f354db0660a"
+  integrity sha512-8ZYiJ3A/3OkDd093CBT/0UKDWry7ak4BdPTFP2+QEP7cmhouyq/Up709ASSj2cK02BbZiMgk7kYjZNS4QP5qrQ==
+  dependencies:
+    rrweb-cssom "^0.6.0"
+
 csstype@^3.0.2:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
@@ -1645,6 +1659,14 @@ data-urls@^3.0.2:
     whatwg-mimetype "^3.0.0"
     whatwg-url "^11.0.0"
 
+data-urls@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-5.0.0.tgz#2f76906bce1824429ffecb6920f45a0b30f00dde"
+  integrity sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==
+  dependencies:
+    whatwg-mimetype "^4.0.0"
+    whatwg-url "^14.0.0"
+
 debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
@@ -1652,7 +1674,7 @@ debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   dependencies:
     ms "2.1.2"
 
-decimal.js@^10.4.2:
+decimal.js@^10.4.2, decimal.js@^10.4.3:
   version "10.4.3"
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.3.tgz#1044092884d245d1b7f65725fa4ad4c6f781cc23"
   integrity sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==
@@ -2304,6 +2326,13 @@ html-encoding-sniffer@^3.0.0:
   dependencies:
     whatwg-encoding "^2.0.0"
 
+html-encoding-sniffer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz#696df529a7cfd82446369dc5193e590a3735b448"
+  integrity sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==
+  dependencies:
+    whatwg-encoding "^3.1.1"
+
 html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
@@ -2318,6 +2347,14 @@ http-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
+http-proxy-agent@^7.0.0:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz#9a8b1f246866c028509486585f62b8f2c18c270e"
+  integrity sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==
+  dependencies:
+    agent-base "^7.1.0"
+    debug "^4.3.4"
+
 http-response-object@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/http-response-object/-/http-response-object-3.0.2.tgz#7f435bb210454e4360d074ef1f989d5ea8aa9810"
@@ -2331,6 +2368,14 @@ https-proxy-agent@^5.0.0, https-proxy-agent@^5.0.1:
   integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
   dependencies:
     agent-base "6"
+    debug "4"
+
+https-proxy-agent@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz#8e97b841a029ad8ddc8731f26595bad868cb4168"
+  integrity sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==
+  dependencies:
+    agent-base "^7.0.2"
     debug "4"
 
 human-signals@^2.1.0:
@@ -3129,6 +3174,33 @@ jsdom@^20.0.0:
     ws "^8.11.0"
     xml-name-validator "^4.0.0"
 
+jsdom@^24.0.0:
+  version "24.0.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-24.0.0.tgz#e2dc04e4c79da368481659818ee2b0cd7c39007c"
+  integrity sha512-UDS2NayCvmXSXVP6mpTj+73JnNQadZlr9N68189xib2tx5Mls7swlTNao26IoHv46BZJFvXygyRtyXd1feAk1A==
+  dependencies:
+    cssstyle "^4.0.1"
+    data-urls "^5.0.0"
+    decimal.js "^10.4.3"
+    form-data "^4.0.0"
+    html-encoding-sniffer "^4.0.0"
+    http-proxy-agent "^7.0.0"
+    https-proxy-agent "^7.0.2"
+    is-potential-custom-element-name "^1.0.1"
+    nwsapi "^2.2.7"
+    parse5 "^7.1.2"
+    rrweb-cssom "^0.6.0"
+    saxes "^6.0.0"
+    symbol-tree "^3.2.4"
+    tough-cookie "^4.1.3"
+    w3c-xmlserializer "^5.0.0"
+    webidl-conversions "^7.0.0"
+    whatwg-encoding "^3.1.1"
+    whatwg-mimetype "^4.0.0"
+    whatwg-url "^14.0.0"
+    ws "^8.16.0"
+    xml-name-validator "^5.0.0"
+
 jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
@@ -3360,6 +3432,11 @@ nwsapi@^2.2.2:
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.4.tgz#fd59d5e904e8e1f03c25a7d5a15cfa16c714a1e5"
   integrity sha512-NHj4rzRo0tQdijE9ZqAx6kYDcoRwYwSYzCA8MY3JzfxlrvEU0jhnhJT9BhqhJs7I/dKcrDm6TyulaRqZPIhN5g==
 
+nwsapi@^2.2.7:
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.7.tgz#738e0707d3128cb750dddcfe90e4610482df0f30"
+  integrity sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==
+
 object-inspect@^1.9.0:
   version "1.12.3"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.3.tgz#ba62dffd67ee256c8c086dfae69e016cd1f198b9"
@@ -3481,7 +3558,7 @@ parse-json@^5.2.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
-parse5@^7.0.0, parse5@^7.1.1:
+parse5@^7.0.0, parse5@^7.1.1, parse5@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.1.2.tgz#0736bebbfd77793823240a23b7fc5e010b7f8e32"
   integrity sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==
@@ -3602,6 +3679,11 @@ punycode@^2.1.0, punycode@^2.1.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
   integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==
+
+punycode@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
+  integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
 pure-rand@^6.0.0:
   version "6.0.2"
@@ -3760,6 +3842,11 @@ rimraf@^5.0.5:
   integrity sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==
   dependencies:
     glob "^10.3.7"
+
+rrweb-cssom@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz#ed298055b97cbddcdeb278f904857629dec5e0e1"
+  integrity sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==
 
 run-parallel@^1.1.9:
   version "1.2.0"
@@ -4035,7 +4122,7 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-tough-cookie@^4.1.2:
+tough-cookie@^4.1.2, tough-cookie@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.3.tgz#97b9adb0728b42280aa3d814b6b999b2ff0318bf"
   integrity sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==
@@ -4051,6 +4138,13 @@ tr46@^3.0.0:
   integrity sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==
   dependencies:
     punycode "^2.1.1"
+
+tr46@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-5.0.0.tgz#3b46d583613ec7283020d79019f1335723801cec"
+  integrity sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==
+  dependencies:
+    punycode "^2.3.1"
 
 ts-api-utils@^1.0.1:
   version "1.0.3"
@@ -4195,6 +4289,13 @@ w3c-xmlserializer@^4.0.0:
   dependencies:
     xml-name-validator "^4.0.0"
 
+w3c-xmlserializer@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz#f925ba26855158594d907313cedd1476c5967f6c"
+  integrity sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==
+  dependencies:
+    xml-name-validator "^5.0.0"
+
 walker@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.8.tgz#bd498db477afe573dc04185f011d3ab8a8d7653f"
@@ -4214,10 +4315,22 @@ whatwg-encoding@^2.0.0:
   dependencies:
     iconv-lite "0.6.3"
 
+whatwg-encoding@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz#d0f4ef769905d426e1688f3e34381a99b60b76e5"
+  integrity sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==
+  dependencies:
+    iconv-lite "0.6.3"
+
 whatwg-mimetype@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz#5fa1a7623867ff1af6ca3dc72ad6b8a4208beba7"
   integrity sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==
+
+whatwg-mimetype@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz#bc1bf94a985dc50388d54a9258ac405c3ca2fc0a"
+  integrity sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==
 
 whatwg-url@^11.0.0:
   version "11.0.0"
@@ -4225,6 +4338,14 @@ whatwg-url@^11.0.0:
   integrity sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==
   dependencies:
     tr46 "^3.0.0"
+    webidl-conversions "^7.0.0"
+
+whatwg-url@^14.0.0:
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-14.0.0.tgz#00baaa7fd198744910c4b1ef68378f2200e4ceb6"
+  integrity sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==
+  dependencies:
+    tr46 "^5.0.0"
     webidl-conversions "^7.0.0"
 
 which-boxed-primitive@^1.0.2:
@@ -4308,10 +4429,20 @@ ws@^8.11.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.13.0.tgz#9a9fb92f93cf41512a0735c8f4dd09b8a1211cd0"
   integrity sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==
 
+ws@^8.16.0:
+  version "8.16.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.16.0.tgz#d1cd774f36fbc07165066a60e40323eab6446fd4"
+  integrity sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==
+
 xml-name-validator@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-4.0.0.tgz#79a006e2e63149a8600f15430f0a4725d1524835"
   integrity sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==
+
+xml-name-validator@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-5.0.0.tgz#82be9b957f7afdacf961e5980f1bf227c0bf7673"
+  integrity sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==
 
 xmlchars@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
# Issue

No issue

## Details

Ensures there are no exceptions thrown when using in an environment where `window` is `undefined`.

This means the package can be used in an environment such as Node where there is no such global.

## CheckList

- [x] Has been tested (where required).
