### PR TITLE
fix: implement radio group logic

### DIFF
--- a/src/getNodeAccessibilityData/getAccessibleAttributeLabels/getLabelFromImplicitHtmlElementValue/getSet.ts
+++ b/src/getNodeAccessibilityData/getAccessibleAttributeLabels/getLabelFromImplicitHtmlElementValue/getSet.ts
@@ -16,6 +16,22 @@ const getFirstNestedChildrenByRole = ({
     return getFirstNestedChildrenByRole({ role, tree: child });
   });
 
+const getParentByRole = ({
+  role,
+  tree,
+}: {
+  role: string;
+  tree: AccessibilityNodeTree;
+}): AccessibilityNodeTree => {
+  let parentTree = tree;
+
+  while (parentTree.role !== role && parentTree.parentAccessibilityNodeTree) {
+    parentTree = parentTree.parentAccessibilityNodeTree;
+  }
+
+  return parentTree;
+};
+
 const getSiblingsByRoleAndLevel = ({
   role,
   parentRole = role,
@@ -25,30 +41,13 @@ const getSiblingsByRoleAndLevel = ({
   parentRole?: string;
   tree: AccessibilityNodeTree;
 }): AccessibilityNodeTree[] => {
-  let parentTree = tree;
-
-  while (
-    parentTree.role !== parentRole &&
-    parentTree.parentAccessibilityNodeTree
-  ) {
-    parentTree = parentTree.parentAccessibilityNodeTree;
-  }
+  const parentTree = getParentByRole({ role: parentRole, tree });
 
   return getFirstNestedChildrenByRole({ role, tree: parentTree });
 };
 
-const getFormOwnerTree = ({ tree }: { tree: AccessibilityNodeTree }) => {
-  let formOwnerTree: AccessibilityNodeTree = tree;
-
-  while (
-    formOwnerTree.role !== "form" &&
-    formOwnerTree.parentAccessibilityNodeTree
-  ) {
-    formOwnerTree = formOwnerTree.parentAccessibilityNodeTree;
-  }
-
-  return formOwnerTree;
-};
+const getFormOwnerTree = ({ tree }: { tree: AccessibilityNodeTree }) =>
+  getParentByRole({ role: "form", tree });
 
 const getRadioInputsByName = ({
   name,

--- a/src/getNodeAccessibilityData/getAccessibleAttributeLabels/getLabelFromImplicitHtmlElementValue/getSet.ts
+++ b/src/getNodeAccessibilityData/getAccessibleAttributeLabels/getLabelFromImplicitHtmlElementValue/getSet.ts
@@ -1,4 +1,5 @@
 import type { AccessibilityNodeTree } from "../../../createAccessibilityTree";
+import { isElement } from "../../../isElement";
 
 const getFirstNestedChildrenByRole = ({
   role,
@@ -17,18 +18,101 @@ const getFirstNestedChildrenByRole = ({
 
 const getSiblingsByRoleAndLevel = ({
   role,
+  parentRole = role,
   tree,
 }: {
   role: string;
+  parentRole?: string;
   tree: AccessibilityNodeTree;
 }): AccessibilityNodeTree[] => {
   let parentTree = tree;
 
-  while (parentTree.role !== role && parentTree.parentAccessibilityNodeTree) {
+  while (
+    parentTree.role !== parentRole &&
+    parentTree.parentAccessibilityNodeTree
+  ) {
     parentTree = parentTree.parentAccessibilityNodeTree;
   }
 
   return getFirstNestedChildrenByRole({ role, tree: parentTree });
+};
+
+const getFormOwnerTree = ({ tree }: { tree: AccessibilityNodeTree }) => {
+  let formOwnerTree: AccessibilityNodeTree = tree;
+
+  while (
+    formOwnerTree.role !== "form" &&
+    formOwnerTree.parentAccessibilityNodeTree
+  ) {
+    formOwnerTree = formOwnerTree.parentAccessibilityNodeTree;
+  }
+
+  return formOwnerTree;
+};
+
+const getRadioInputsByName = ({
+  name,
+  tree,
+}: {
+  name: string;
+  tree: AccessibilityNodeTree;
+}): AccessibilityNodeTree[] =>
+  tree.children.flatMap((child) => {
+    if (isElement(child.node) && child.node.getAttribute("name") === name) {
+      return child;
+    }
+
+    return getRadioInputsByName({ name, tree: child });
+  });
+
+/**
+ * The radio button group that contains an input element a also contains all
+ * the other input elements b that fulfill all of the following conditions:
+ *
+ * - The input element b's type attribute is in the Radio Button state.
+ * - Either a and b have the same form owner, or they both have no form owner.
+ * - Both a and b are in the same tree.
+ * - They both have a name attribute, their name attributes are not empty, and
+ *   the value of a's name attribute equals the value of b's name attribute.
+ *
+ * REF: https://html.spec.whatwg.org/multipage/input.html#radio-button-group
+ */
+const getRadioGroup = ({
+  node,
+  tree,
+}: {
+  node: HTMLElement;
+  tree: AccessibilityNodeTree;
+}) => {
+  /**
+   * Authors SHOULD ensure that elements with role radio are explicitly grouped
+   * in order to indicate which ones affect the same value. This is achieved by
+   * enclosing the radio elements in an element with role radiogroup. If it is
+   * not possible to make the radio buttons DOM children of the radiogroup,
+   * authors SHOULD use the aria-owns attribute on the radiogroup element to
+   * indicate the relationship to its children.
+   */
+  if (node.localName !== "input") {
+    return getSiblingsByRoleAndLevel({
+      role: "radio",
+      parentRole: "radiogroup",
+      tree,
+    });
+  }
+
+  if (!node.hasAttribute("name")) {
+    return [];
+  }
+
+  const name = node.getAttribute("name")!;
+
+  if (!name) {
+    return [];
+  }
+
+  const formOwnerTree = getFormOwnerTree({ tree });
+
+  return getRadioInputsByName({ name, tree: formOwnerTree });
 };
 
 const getChildrenByRole = ({
@@ -75,14 +159,27 @@ const getChildrenByRole = ({
  * REF: https://www.w3.org/TR/core-aam-1.2/#mapping_additional_position
  */
 export const getSet = ({
+  node,
   role,
   tree,
 }: {
-  role: string;
+  node: HTMLElement;
   tree: AccessibilityNodeTree;
-}): AccessibilityNodeTree[] => {
+  role: string;
+}): Pick<AccessibilityNodeTree, "node">[] => {
   if (role === "treeitem") {
     return getSiblingsByRoleAndLevel({ role, tree });
+  }
+
+  /**
+   * With aria-setsize value reflecting number of type=radio input elements
+   * within the radio button group and aria-posinset value reflecting the
+   * elements position within the radio button group.
+   *
+   * REF: https://www.w3.org/TR/html-aam-1.0/#el-input-radio
+   */
+  if (role === "radio") {
+    return getRadioGroup({ node, tree });
   }
 
   return getChildrenByRole({

--- a/test/int/accessibleValue.int.test.ts
+++ b/test/int/accessibleValue.int.test.ts
@@ -78,9 +78,7 @@ describe("Placeholder Attribute Property", () => {
     await virtual.next();
     await virtual.next();
 
-    expect(await virtual.lastSpokenPhrase()).toBe(
-      "radio, Label, not checked, position 1, set size 1"
-    );
+    expect(await virtual.lastSpokenPhrase()).toBe("radio, Label, not checked");
 
     await virtual.stop();
   });
@@ -95,9 +93,7 @@ describe("Placeholder Attribute Property", () => {
     await virtual.next();
     await virtual.next();
 
-    expect(await virtual.lastSpokenPhrase()).toBe(
-      "radio, Label, not checked, position 1, set size 1"
-    );
+    expect(await virtual.lastSpokenPhrase()).toBe("radio, Label, not checked");
 
     await virtual.stop();
   });

--- a/test/int/radioGroup.int.test.tsx
+++ b/test/int/radioGroup.int.test.tsx
@@ -1,0 +1,161 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { virtual } from "../../src/index.js";
+
+it("should work for sibling radio inputs", async () => {
+  const { container } = render(
+    <main>
+      <fieldset>
+        <legend>Example</legend>
+        <input type="radio" name="example" id="option1" />
+        <label htmlFor="option1">Option 1</label>
+        <input type="radio" name="example" id="option2" />
+        <label htmlFor="option2">Option 2</label>
+      </fieldset>
+    </main>
+  );
+
+  await virtual.start({ container });
+
+  while ((await virtual.lastSpokenPhrase()) !== "end of main") {
+    await virtual.next();
+  }
+
+  expect(await virtual.spokenPhraseLog()).toEqual([
+    "main",
+    "group, Example",
+    "legend, Example",
+    "radio, Option 1, not checked, position 1, set size 2",
+    "Option 1",
+    "radio, Option 2, not checked, position 2, set size 2",
+    "Option 2",
+    "end of group, Example",
+    "end of main",
+  ]);
+  await virtual.stop();
+});
+
+it("should work for nested radio inputs", async () => {
+  const { container } = render(
+    <main>
+      <fieldset>
+        <legend>Example</legend>
+        <div>
+          <input type="radio" name="example" id="option1" />
+          <label htmlFor="option1">Option 1</label>
+        </div>
+        <div>
+          <input type="radio" name="example" id="option2" />
+          <label htmlFor="option2">Option 2</label>
+        </div>
+      </fieldset>
+    </main>
+  );
+
+  await virtual.start({ container });
+
+  while ((await virtual.lastSpokenPhrase()) !== "end of main") {
+    await virtual.next();
+  }
+
+  expect(await virtual.spokenPhraseLog()).toEqual([
+    "main",
+    "group, Example",
+    "legend, Example",
+    "radio, Option 1, not checked, position 1, set size 2",
+    "Option 1",
+    "radio, Option 2, not checked, position 2, set size 2",
+    "Option 2",
+    "end of group, Example",
+    "end of main",
+  ]);
+  await virtual.stop();
+});
+
+it("should work for radio inputs when some are hidden", async () => {
+  const { container } = render(
+    <main>
+      <fieldset>
+        <legend>Example</legend>
+        <input type="radio" name="example" id="option1" />
+        <label htmlFor="option1">Option 1</label>
+        <input aria-hidden={true} type="radio" name="example" id="option2" />
+        <label aria-hidden={true} htmlFor="option2">
+          Option 2
+        </label>
+      </fieldset>
+    </main>
+  );
+
+  await virtual.start({ container });
+
+  while ((await virtual.lastSpokenPhrase()) !== "end of main") {
+    await virtual.next();
+  }
+
+  expect(await virtual.spokenPhraseLog()).toEqual([
+    "main",
+    "group, Example",
+    "legend, Example",
+    "radio, Option 1, not checked, position 1, set size 1",
+    "Option 1",
+    "end of group, Example",
+    "end of main",
+  ]);
+  await virtual.stop();
+});
+
+it("should consider parent forms when group inputs", async () => {
+  const { container } = render(
+    <main>
+      <form name="formA">
+        <fieldset>
+          <legend>Example A</legend>
+          <input type="radio" name="example" id="option1a" />
+          <label htmlFor="option1a">Option 1a</label>
+          <input type="radio" name="example" id="option2a" />
+          <label htmlFor="option2a">Option 2a</label>
+        </fieldset>
+      </form>
+      <form name="formB">
+        <fieldset>
+          <legend>Example B</legend>
+          <input type="radio" name="example" id="option1b" />
+          <label htmlFor="option1b">Option 1b</label>
+          <input type="radio" name="example" id="option2b" />
+          <label htmlFor="option2b">Option 2b</label>
+        </fieldset>
+      </form>
+    </main>
+  );
+
+  await virtual.start({ container });
+
+  while ((await virtual.lastSpokenPhrase()) !== "end of main") {
+    await virtual.next();
+  }
+
+  expect(await virtual.spokenPhraseLog()).toEqual([
+    "main",
+    "form",
+    "group, Example A",
+    "legend, Example A",
+    "radio, Option 1a, not checked, position 1, set size 2",
+    "Option 1a",
+    "radio, Option 2a, not checked, position 2, set size 2",
+    "Option 2a",
+    "end of group, Example A",
+    "end of form",
+    "form",
+    "group, Example B",
+    "legend, Example B",
+    "radio, Option 1b, not checked, position 1, set size 2",
+    "Option 1b",
+    "radio, Option 2b, not checked, position 2, set size 2",
+    "Option 2b",
+    "end of group, Example B",
+    "end of form",
+    "end of main",
+  ]);
+  await virtual.stop();
+});


### PR DESCRIPTION
# Issue

Fixes #67.

## Details

Implements the radio group algorithm (extended to cater for explicit `radio` and `radiogroup` role usage) for determining set size and position.

## CheckList

- [x] Has been tested (where required).
