### PR TITLE
feat: basic `inert` attribute support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guidepup/virtual-screen-reader",
-  "version": "0.29.1",
+  "version": "0.30.0",
   "description": "Virtual Screen Reader driver for unit test automation.",
   "author": "Craig Morten <craig.morten@hotmail.co.uk>",
   "license": "MIT",

--- a/src/flattenTree.ts
+++ b/src/flattenTree.ts
@@ -57,10 +57,11 @@ export function flattenTree(
   };
 
   const isAnnounced =
-    !!treeNodeWithAttributeLabels.accessibleName ||
-    !!treeNodeWithAttributeLabels.accessibleDescription ||
-    treeNodeWithAttributeLabels.accessibleAttributeLabels.length > 0 ||
-    !!treeNodeWithAttributeLabels.spokenRole;
+    !treeNodeWithAttributeLabels.isInert &&
+    (!!treeNodeWithAttributeLabels.accessibleName ||
+      !!treeNodeWithAttributeLabels.accessibleDescription ||
+      treeNodeWithAttributeLabels.accessibleAttributeLabels.length > 0 ||
+      !!treeNodeWithAttributeLabels.spokenRole);
 
   const ignoreChildren = shouldIgnoreChildren(tree);
 

--- a/src/isHiddenFromAccessibilityTree.ts
+++ b/src/isHiddenFromAccessibilityTree.ts
@@ -1,0 +1,46 @@
+import { isElement } from "./isElement";
+
+const TEXT_NODE = 3;
+
+export function isHiddenFromAccessibilityTree(node: Node | null): node is null {
+  if (!node) {
+    return true;
+  }
+
+  // `node.textContent` is only `null` for `document` and `doctype`.
+
+  if (node.nodeType === TEXT_NODE && node.textContent!.trim()) {
+    return false;
+  }
+
+  if (!isElement(node)) {
+    return true;
+  }
+
+  try {
+    if (node.hidden === true) {
+      return true;
+    }
+
+    if (node.getAttribute("aria-hidden") === "true") {
+      return true;
+    }
+
+    const getComputedStyle = node.ownerDocument.defaultView?.getComputedStyle;
+    const computedStyle = getComputedStyle?.(node);
+
+    if (
+      computedStyle?.visibility === "hidden" ||
+      computedStyle?.display === "none"
+    ) {
+      return true;
+    }
+  } catch {
+    // Some elements aren't supported by DOM implementations such as JSDOM.
+    // E.g. `<math>`, see https://github.com/jsdom/jsdom/issues/3515
+    // We ignore these nodes at the moment as we can't support them.
+    return true;
+  }
+
+  return false;
+}

--- a/test/int/inert.int.test.ts
+++ b/test/int/inert.int.test.ts
@@ -1,0 +1,119 @@
+import { virtual } from "../../src/index.js";
+
+describe("inert", () => {
+  afterEach(async () => {
+    await virtual.stop();
+
+    document.body.innerHTML = "";
+  });
+
+  it("should hide inert elements from the tree unless they are modal dialog (non-native)", async () => {
+    document.body.innerHTML = `<p>visible paragraph</p>
+<p inert>hidden paragraph</p>
+
+<!-- Explicitly inert modal dialog should be inert -->
+<div aria-labelledby="dialog-heading-1" aria-modal="true" inert role="dialog">
+  <h1 id="dialog-heading-1">hidden dialog heading 1</h1>
+</div>
+
+<!-- Explicitly inert dialog should be inert -->
+<div aria-labelledby="dialog-heading-2" inert role="dialog">
+  <h1 id="dialog-heading-2">hidden dialog heading 2</h1>
+</div>
+
+<div inert>
+  <p>hidden paragraph</p>
+
+  <!-- Explicitly inert modal dialog should be inert -->
+  <div aria-labelledby="dialog-heading-3" aria-modal="true" inert role="dialog">
+    <h1 id="dialog-heading-3">hidden dialog heading 3</h1>
+  </div>
+
+  <!-- Non-modal dialog should inherit inert -->
+  <div aria-labelledby="dialog-heading-4" role="dialog">
+    <h1 id="dialog-heading-4">hidden dialog heading 4</h1>
+  </div>
+
+  <!-- Modal dialog should not inherit inert -->
+  <div aria-labelledby="dialog-heading-5" aria-modal="true" role="dialog">
+    <h1 id="dialog-heading-5">visible dialog heading 5</h1>
+  </div>
+</div>
+`;
+
+    await virtual.start({ container: document.body });
+
+    while (
+      (await virtual.lastSpokenPhrase()) !==
+      "end of dialog, visible dialog heading 5, modal"
+    ) {
+      await virtual.next();
+    }
+
+    expect(await virtual.spokenPhraseLog()).toEqual([
+      "document",
+      "paragraph",
+      "visible paragraph",
+      "end of paragraph",
+      "dialog, visible dialog heading 5, modal",
+      "dialog, visible dialog heading 5, modal",
+      "heading, visible dialog heading 5, level 1",
+      "end of dialog, visible dialog heading 5, modal",
+    ]);
+  });
+
+  it("should hide inert elements from the tree unless they are modal dialog (native approximation assuming used `openModel()` method)", async () => {
+    document.body.innerHTML = `<p>visible paragraph</p>
+<p inert>hidden paragraph</p>
+
+<!-- Explicitly inert open dialog should be inert -->
+<dialog aria-labelledby="dialog-heading-1" inert open>
+  <h1 id="dialog-heading-1">hidden dialog heading 1</h1>
+</dialog>
+
+<!-- Explicitly inert closed dialog should be inert -->
+<dialog aria-labelledby="dialog-heading-2" inert>
+  <h1 id="dialog-heading-2">hidden dialog heading 2</h1>
+</dialog>
+
+<div inert>
+  <p>hidden paragraph</p>
+
+  <!-- Explicitly inert open dialog should be inert -->
+  <dialog aria-labelledby="dialog-heading-3" inert open>
+    <h1 id="dialog-heading-3">hidden dialog heading 3</h1>
+  </dialog>
+
+  <!-- Closed dialog should inherit inert -->
+  <dialog aria-labelledby="dialog-heading-4">
+    <h1 id="dialog-heading-4">hidden dialog heading 4</h1>
+  </dialog>
+
+  <!-- Open dialog should not inherit inert -->
+  <dialog aria-labelledby="dialog-heading-5" open>
+    <h1 id="dialog-heading-5">visible dialog heading 5</h1>
+  </dialog>
+</div>
+`;
+
+    await virtual.start({ container: document.body });
+
+    while (
+      (await virtual.lastSpokenPhrase()) !==
+      "end of dialog, visible dialog heading 5"
+    ) {
+      await virtual.next();
+    }
+
+    expect(await virtual.spokenPhraseLog()).toEqual([
+      "document",
+      "paragraph",
+      "visible paragraph",
+      "end of paragraph",
+      "dialog, visible dialog heading 5",
+      "dialog, visible dialog heading 5",
+      "heading, visible dialog heading 5, level 1",
+      "end of dialog, visible dialog heading 5",
+    ]);
+  });
+});


### PR DESCRIPTION
# Issue

Fixes #129 

## Details

Adds initial basic support for hiding nodes from the accessibility tree based on `inert` attribute behaviour.

TODO: this change does not fully support native `dialog` element behaviours properly, can revisit later.

## CheckList

- [x] Has been tested (where required).
