### PR TITLE
Allow custom advanceTimers implementation and update tick to microtask based approach

### DIFF
--- a/src/Virtual.ts
+++ b/src/Virtual.ts
@@ -8,13 +8,13 @@ import {
   ERR_VIRTUAL_NOT_STARTED,
 } from "./errors";
 import { getLiveSpokenPhrase, LIVE } from "./getLiveSpokenPhrase";
+import { UserEvent, userEvent } from "@testing-library/user-event";
 import { flattenTree } from "./flattenTree";
 import { getElementNode } from "./commands/getElementNode";
 import { getItemText } from "./getItemText";
 import { getSpokenPhrase } from "./getSpokenPhrase";
 import { observeDOM } from "./observeDOM";
 import { tick } from "./tick";
-import { userEvent } from "@testing-library/user-event";
 import type { VirtualCommandArgs } from "./commands/types";
 
 /**
@@ -100,6 +100,15 @@ export interface StartOptions {
    * Defaults to `false`.
    */
   displayCursor?: boolean;
+
+  /**
+   * A function to be called internally to advance your fake timers (if applicable)
+   *
+   * @example jest.advanceTimersByTime
+   *
+   * @returns A promise that resolves after the specified delay, or void if not asynchronous.
+   */
+  advanceTimers?: (delay: number) => Promise<void> | void;
 }
 
 const defaultUserEventOptions = {
@@ -206,9 +215,16 @@ export class Virtual {
   #treeCache: AccessibilityNode[] | null = null;
   #disconnectDOMObserver: (() => void) | null = null;
   #boundHandleFocusChange: ((event: Event) => Promise<void>) | null = null;
+  #userEvent: UserEvent | null = null;
 
   #checkContainer() {
     if (!this.#container) {
+      throw new Error(ERR_VIRTUAL_NOT_STARTED);
+    }
+  }
+
+  #checkUserEvent() {
+    if (!this.#userEvent) {
       throw new Error(ERR_VIRTUAL_NOT_STARTED);
     }
   }
@@ -284,7 +300,7 @@ export class Virtual {
      * REF: https://www.w3.org/TR/wai-aria-1.2/#aria-modal
      */
     return tree.filter(
-      ({ parentDialog }) => this.#activeNode!.parentDialog === parentDialog
+      ({ parentDialog }) => this.#activeNode!.parentDialog === parentDialog,
     );
   }
 
@@ -330,7 +346,7 @@ export class Virtual {
         getLiveSpokenPhrase({
           container,
           mutation,
-        })
+        }),
       )
       .filter(Boolean)
       .forEach((spokenPhrase) => {
@@ -342,7 +358,7 @@ export class Virtual {
     return this.#spokenPhraseLog.filter(
       (spokenPhrase) =>
         !spokenPhrase.startsWith(LIVE.ASSERTIVE) &&
-        !spokenPhrase.startsWith(LIVE.POLITE)
+        !spokenPhrase.startsWith(LIVE.POLITE),
     );
   }
 
@@ -368,7 +384,7 @@ export class Virtual {
       // cursor has changed.
       const tree = this.#getAccessibilityTree();
       const parentDialogNode = tree.find(
-        ({ node }) => node === accessibilityNode.parentDialog
+        ({ node }) => node === accessibilityNode.parentDialog,
       )!;
 
       const spokenPhrase = getSpokenPhrase(parentDialogNode);
@@ -426,7 +442,7 @@ export class Virtual {
         accessibleValue === this.#activeNode?.accessibleValue &&
         node === this.#activeNode?.node &&
         role === this.#activeNode?.role &&
-        spokenRole === this.#activeNode?.spokenRole
+        spokenRole === this.#activeNode?.spokenRole,
     );
   }
 
@@ -490,8 +506,8 @@ export class Virtual {
   get commands() {
     return Object.fromEntries<keyof VirtualCommands>(
       (Object.keys(commands) as (keyof VirtualCommands)[]).map(
-        (command: keyof VirtualCommands) => [command, command]
-      )
+        (command: keyof VirtualCommands) => [command, command],
+      ),
     ) as { [K in keyof VirtualCommands]: K };
   }
 
@@ -568,10 +584,15 @@ export class Virtual {
   // @ts-ignore for non-TS users we default the container to `null` which
   // prompts the missing container error.
   async start(
-    { container, displayCursor = false, window: root }: StartOptions = {
+    {
+      container,
+      displayCursor = false,
+      window: root,
+      advanceTimers,
+    }: StartOptions = {
       container: null as never,
       displayCursor: false,
-    }
+    },
   ) {
     if (!container) {
       throw new Error(ERR_VIRTUAL_MISSING_CONTAINER);
@@ -593,8 +614,14 @@ export class Virtual {
       (mutations: MutationRecord[]) => {
         this.#invalidateTreeCache();
         this.#announceLiveRegions(mutations);
-      }
+      },
     );
+
+    this.#userEvent = userEvent.setup({
+      ...defaultUserEventOptions,
+      document: container.ownerDocument ?? globalThis.document,
+      ...(advanceTimers ? { advanceTimers } : {}),
+    });
 
     const tree = this.#getAccessibilityTree();
 
@@ -634,7 +661,10 @@ export class Virtual {
    */
   async stop() {
     this.#disconnectDOMObserver?.();
-    this.#container?.removeEventListener("focusin", this.#boundHandleFocusChange);
+    this.#container?.removeEventListener(
+      "focusin",
+      this.#boundHandleFocusChange,
+    );
     this.#invalidateTreeCache();
 
     if (this.#cursor) {
@@ -647,6 +677,7 @@ export class Virtual {
     this.#itemTextLog = [];
     this.#spokenPhraseLog = [];
     this.#boundHandleFocusChange = null;
+    this.#userEvent = null;
     return;
   }
 
@@ -762,6 +793,8 @@ export class Virtual {
    */
   async act() {
     this.#checkContainer();
+    this.#checkUserEvent();
+
     await tick();
 
     if (!this.#activeNode) {
@@ -776,7 +809,7 @@ export class Virtual {
      *
      * REF: https://www.w3.org/TR/core-aam-1.2/#mapping_actions
      */
-    await userEvent.click(target, defaultUserEventOptions);
+    await this.#userEvent?.click(target);
 
     return;
   }
@@ -850,6 +883,7 @@ export class Virtual {
    */
   async press(key: string) {
     this.#checkContainer();
+    this.#checkUserEvent();
     await tick();
 
     if (!this.#activeNode) {
@@ -878,7 +912,7 @@ export class Virtual {
     ].join("");
 
     this.#focusActiveElement();
-    await userEvent.keyboard(keyboardCommand, defaultUserEventOptions);
+    await this.#userEvent?.keyboard(keyboardCommand);
     await this.#refreshState(true);
 
     return;
@@ -911,6 +945,7 @@ export class Virtual {
    */
   async type(text: string) {
     this.#checkContainer();
+    this.#checkUserEvent();
     await tick();
 
     if (!this.#activeNode) {
@@ -918,7 +953,7 @@ export class Virtual {
     }
 
     const target = getElementNode(this.#activeNode);
-    await userEvent.type(target, text, defaultUserEventOptions);
+    await this.#userEvent?.type(target, text);
     await this.#refreshState(true);
 
     return;
@@ -949,7 +984,7 @@ export class Virtual {
    */
   async perform<
     T extends keyof VirtualCommands,
-    K extends Omit<Parameters<VirtualCommands[T]>[0], keyof VirtualCommandArgs>
+    K extends Omit<Parameters<VirtualCommands[T]>[0], keyof VirtualCommandArgs>,
   >(command: T, options?: { [L in keyof K]: K[L] }) {
     this.#checkContainer();
     await tick();
@@ -1013,6 +1048,7 @@ export class Virtual {
    */
   async click({ button = "left", clickCount = 1 } = {}) {
     this.#checkContainer();
+    this.#checkUserEvent();
     await tick();
 
     if (!this.#activeNode) {
@@ -1023,10 +1059,7 @@ export class Virtual {
     const keys = key.repeat(clickCount);
     const target = getElementNode(this.#activeNode);
 
-    await userEvent.pointer(
-      [{ target }, { keys, target }],
-      defaultUserEventOptions
-    );
+    await this.#userEvent?.pointer([{ target }, { keys, target }]);
 
     return;
   }

--- a/src/Virtual.ts
+++ b/src/Virtual.ts
@@ -223,12 +223,6 @@ export class Virtual {
     }
   }
 
-  #checkUserEvent() {
-    if (!this.#userEvent) {
-      throw new Error(ERR_VIRTUAL_NOT_STARTED);
-    }
-  }
-
   #createCursor(root: Root | undefined) {
     if (!root?.document) {
       return;
@@ -793,7 +787,6 @@ export class Virtual {
    */
   async act() {
     this.#checkContainer();
-    this.#checkUserEvent();
 
     await tick();
 
@@ -883,7 +876,6 @@ export class Virtual {
    */
   async press(key: string) {
     this.#checkContainer();
-    this.#checkUserEvent();
     await tick();
 
     if (!this.#activeNode) {
@@ -945,7 +937,6 @@ export class Virtual {
    */
   async type(text: string) {
     this.#checkContainer();
-    this.#checkUserEvent();
     await tick();
 
     if (!this.#activeNode) {
@@ -1048,7 +1039,6 @@ export class Virtual {
    */
   async click({ button = "left", clickCount = 1 } = {}) {
     this.#checkContainer();
-    this.#checkUserEvent();
     await tick();
 
     if (!this.#activeNode) {

--- a/src/Virtual.ts
+++ b/src/Virtual.ts
@@ -809,7 +809,7 @@ export class Virtual {
      *
      * REF: https://www.w3.org/TR/core-aam-1.2/#mapping_actions
      */
-    await this.#userEvent?.click(target);
+    await this.#userEvent!.click(target);
 
     return;
   }
@@ -912,7 +912,7 @@ export class Virtual {
     ].join("");
 
     this.#focusActiveElement();
-    await this.#userEvent?.keyboard(keyboardCommand);
+    await this.#userEvent!.keyboard(keyboardCommand);
     await this.#refreshState(true);
 
     return;
@@ -953,7 +953,7 @@ export class Virtual {
     }
 
     const target = getElementNode(this.#activeNode);
-    await this.#userEvent?.type(target, text);
+    await this.#userEvent!.type(target, text);
     await this.#refreshState(true);
 
     return;
@@ -1059,7 +1059,7 @@ export class Virtual {
     const keys = key.repeat(clickCount);
     const target = getElementNode(this.#activeNode);
 
-    await this.#userEvent?.pointer([{ target }, { keys, target }]);
+    await this.#userEvent!.pointer([{ target }, { keys, target }]);
 
     return;
   }

--- a/src/Virtual.ts
+++ b/src/Virtual.ts
@@ -8,7 +8,7 @@ import {
   ERR_VIRTUAL_NOT_STARTED,
 } from "./errors";
 import { getLiveSpokenPhrase, LIVE } from "./getLiveSpokenPhrase";
-import { UserEvent, userEvent } from "@testing-library/user-event";
+import { type UserEvent, userEvent } from "@testing-library/user-event";
 import { flattenTree } from "./flattenTree";
 import { getElementNode } from "./commands/getElementNode";
 import { getItemText } from "./getItemText";

--- a/src/tick.ts
+++ b/src/tick.ts
@@ -1,3 +1,3 @@
 export async function tick() {
-  return await new Promise<void>((resolve) => setTimeout(() => resolve()));
+  return await Promise.resolve();
 }

--- a/test/int/act.int.test.ts
+++ b/test/int/act.int.test.ts
@@ -10,10 +10,8 @@ function setupButtonPage() {
   const button = document.createElement("button");
 
   button.addEventListener("click", function (event) {
-     
-    document.getElementById(
-      "status"
-    )!.innerHTML = `Clicked ${event.detail} Time(s)`;
+    document.getElementById("status")!.innerHTML =
+      `Clicked ${event.detail} Time(s)`;
   });
 
   button.innerHTML = "Click Me";
@@ -51,7 +49,6 @@ describe("act", () => {
   });
 
   it("should handle requests to perform the default action on hidden container gracefully", async () => {
-     
     const container = document.querySelector("#hidden")!;
 
     await virtual.start({ container });
@@ -60,6 +57,32 @@ describe("act", () => {
 
     expect(await virtual.itemTextLog()).toEqual([]);
     expect(await virtual.spokenPhraseLog()).toEqual([]);
+
+    await virtual.stop();
+  });
+
+  it("should support custom advanceTimers implementations", async () => {
+    const container = document.body;
+
+    const advanceTimers = jest.fn();
+    await virtual.start({ container, advanceTimers });
+
+    expect(getByText(container, "Not Clicked")).toBeInTheDocument();
+
+    while ((await virtual.itemText()) !== "Click Me") {
+      await virtual.next();
+    }
+
+    await virtual.act();
+
+    expect(queryByText(container, "Not Clicked")).not.toBeInTheDocument();
+    expect(getByText(container, "Clicked 1 Time(s)")).toBeInTheDocument();
+    expect(advanceTimers).toHaveBeenCalled();
+
+    await virtual.previous();
+    await virtual.previous();
+
+    expect(await virtual.lastSpokenPhrase()).toEqual("Clicked 1 Time(s)");
 
     await virtual.stop();
   });

--- a/test/int/click.int.test.ts
+++ b/test/int/click.int.test.ts
@@ -10,10 +10,8 @@ function setupButtonPage() {
   const button = document.createElement("button");
 
   button.addEventListener("click", function (event) {
-     
-    document.getElementById(
-      "status"
-    )!.innerHTML = `Clicked ${event.detail} Time(s)`;
+    document.getElementById("status")!.innerHTML =
+      `Clicked ${event.detail} Time(s)`;
   });
 
   button.innerHTML = "Click Me";
@@ -21,7 +19,6 @@ function setupButtonPage() {
   document.body.appendChild(button);
 
   document.body.addEventListener("contextmenu", () => {
-     
     document.getElementById("status")!.innerHTML = "Right Clicked";
   });
 }
@@ -128,7 +125,6 @@ describe("click", () => {
   });
 
   it("should handle requests to click on hidden container gracefully", async () => {
-     
     const container = document.querySelector("#hidden")!;
 
     await virtual.start({ container });
@@ -137,6 +133,33 @@ describe("click", () => {
 
     expect(await virtual.itemTextLog()).toEqual([]);
     expect(await virtual.spokenPhraseLog()).toEqual([]);
+
+    await virtual.stop();
+  });
+
+  it("should support custom advance timers implementations", async () => {
+    const container = document.body;
+
+    const advanceTimers = jest.fn();
+
+    await virtual.start({ container, advanceTimers });
+
+    expect(getByText(container, "Not Clicked")).toBeInTheDocument();
+
+    while ((await virtual.itemText()) !== "Click Me") {
+      await virtual.next();
+    }
+
+    await virtual.click();
+
+    expect(queryByText(container, "Not Clicked")).not.toBeInTheDocument();
+    expect(getByText(container, "Clicked 1 Time(s)")).toBeInTheDocument();
+    expect(advanceTimers).toHaveBeenCalled();
+
+    await virtual.previous();
+    await virtual.previous();
+
+    expect(await virtual.lastSpokenPhrase()).toEqual("Clicked 1 Time(s)");
 
     await virtual.stop();
   });

--- a/test/int/press.int.test.ts
+++ b/test/int/press.int.test.ts
@@ -43,7 +43,6 @@ describe("press", () => {
   });
 
   it("should handle requests to press on hidden container gracefully", async () => {
-     
     const container = document.querySelector("#hidden")!;
 
     await virtual.start({ container });
@@ -65,6 +64,26 @@ describe("press", () => {
 
     expect(await virtual.itemTextLog()).toEqual(["text node"]);
     expect(await virtual.spokenPhraseLog()).toEqual(["text node"]);
+
+    await virtual.stop();
+  });
+
+  it("should support custom advanceTimers implementations", async () => {
+    const advanceTimers = jest.fn();
+    const container = document.body;
+
+    await virtual.start({ container, advanceTimers });
+
+    await virtual.next();
+    await virtual.next();
+
+    expect(await virtual.itemText()).toEqual("Input Some Text");
+
+    await virtual.press("Shift+a+b+c");
+    // TODO: FAIL Testing Library user-event doesn't support modification yet, this should be "ABC"
+    expect(getByRole(container, "textbox")).toHaveValue("abc");
+    expect(await virtual.itemText()).toEqual("Input Some Text, abc");
+    expect(advanceTimers).toHaveBeenCalled();
 
     await virtual.stop();
   });

--- a/test/int/type.int.test.ts
+++ b/test/int/type.int.test.ts
@@ -37,7 +37,6 @@ describe("type", () => {
   });
 
   it("should handle requests to type on hidden container gracefully", async () => {
-     
     const container = document.querySelector("#hidden")!;
 
     await virtual.start({ container });
@@ -46,6 +45,25 @@ describe("type", () => {
 
     expect(await virtual.itemTextLog()).toEqual([]);
     expect(await virtual.spokenPhraseLog()).toEqual([]);
+
+    await virtual.stop();
+  });
+
+  it("should support custom advanceTimers implementations", async () => {
+    const advanceTimers = jest.fn();
+    const container = document.body;
+
+    await virtual.start({ container, advanceTimers });
+
+    await virtual.next();
+    await virtual.next();
+
+    expect(await virtual.itemText()).toEqual("Input Some Text");
+
+    await virtual.type("Hello World!");
+    expect(getByRole(container, "textbox")).toHaveValue("Hello World!");
+    expect(await virtual.itemText()).toEqual("Input Some Text, Hello World!");
+    expect(advanceTimers).toHaveBeenCalled();
 
     await virtual.stop();
   });


### PR DESCRIPTION
# Issue

Fixes #215.

## Details

As discussed in original issue allow providing custom `advanceTimers` implementation to `virtual.start()` which can then be provided to the internal `userEvent` usage. To allow this the `userEvent` usages have been updated to use a shared session created via `userEvent.setup`. This will also ensure the `defaultUserEventOptions` are actually applied as expected as v14 of `@testing-library/user-event` doesn't support passing the options  as a second parameter.

Additionally updated the `tick` helper to use `Promise.resolve` rather than a setTimeout approach to reduce impact of using fake timers.

Verified existing tests pass and added new tests to ensure custom `advanceTimers` is called

## CheckList

- [x] Has been tested (where required).
